### PR TITLE
Replace Minikube with Kind.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.crt
 *.key
 cert-expiry-date.txt
+haproxy.cfg
 TODO.md

--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -19,7 +19,7 @@ For that reason, there are no dashboards available.
 The following deploys a sample dashboard for the TNS application:
 
 ```bash
-kubectl --context lgtm-central create cm tns -n observability --from-file=tns.json
-kubectl --context lgtm-central label cm tns -n observability grafana_dashboard=1 release=monitor
+kubectl --context kind-lgtm-central create cm tns -n observability --from-file=tns.json
+kubectl --context kind-lgtm-central label cm tns -n observability grafana_dashboard=1 release=monitor
 ```
 

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+for cmd in "docker" "kind" "cilium" "kubectl" "jq"; do
+  type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
+done
+
+CONTEXT=${CONTEXT-kind} # Kubeconfig Profile and cluster sub-domain
+WORKERS=${WORKERS-2} # Number of worker nodes in the clusters
+SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for Cilium L2/LB
+CLUSTER_ID=${CLUSTER_ID-1}
+POD_CIDR=${POD_CIDR-10.244.0.0/16}
+SVC_CIDR=${SVC_CIDR-10.96.0.0/12}
+MASTER=${CONTEXT}-control-plane
+CILIUM_VERSION=${CILIUM_VERSION-1.15.1}
+
+# Abort if the cluster exists; if so, ensure the kubeconfig is exported
+if [[ $(kind get clusters | tr '\n' ' ') = *${CONTEXT}* ]]; then
+  echo "Cluster ${CONTEXT} already started"
+  kubectl config use-context kind-${CONTEXT}
+  return
+fi
+
+WORKER_YAML=""
+for ((i = 1; i <= WORKERS; i++)); do
+  WORKER_YAML+="- role: worker"$'\n'
+done
+
+# Deploy Kind Cluster
+cat <<EOF | kind create cluster --config -
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ${CONTEXT}
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    ---
+    apiVersion: kubeadm.k8s.io/v1beta3
+    kind: ClusterConfiguration
+    networking:
+      dnsDomain: "${CONTEXT}.cluster.local"
+${WORKER_YAML}
+networking:
+  ipFamily: ipv4
+  disableDefaultCNI: true
+  kubeProxyMode: none
+  podSubnet: ${POD_CIDR}
+  serviceSubnet: ${SVC_CIDR}
+EOF
+
+cilium install --version ${CILIUM_VERSION} --wait \
+  --set cluster.id=${CLUSTER_ID} \
+  --set cluster.name=${CONTEXT} \
+  --set ipam.mode=kubernetes \
+  --set devices=eth+ \
+  --set l2announcements.enabled=true \
+  --set externalIPs.enabled=true \
+  --set socketLB.enabled=true \
+  --set socketLB.hostNamespaceOnly=true
+
+cilium status --wait
+
+NETWORK=$(docker network inspect kind \
+  | jq -r '.[0].IPAM.Config[] | select(.Gateway != null) | .Subnet')
+
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: ${CONTEXT}-pool
+spec:
+  cidrs:
+  - cidr: "${NETWORK%.*}.${SUBNET}/29"
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumL2AnnouncementPolicy
+metadata:
+  name: ${CONTEXT}-policy
+spec:
+  nodeSelector:
+    matchExpressions:
+    - key: node-role.kubernetes.io/control-plane
+      operator: DoesNotExist
+  interfaces:
+  - ^eth[0-9].*
+  externalIPs: true
+  loadBalancerIPs: true
+EOF

--- a/deploy-linkerd.sh
+++ b/deploy-linkerd.sh
@@ -66,6 +66,8 @@ helm upgrade --install linkerd-viz linkerd/linkerd-viz \
   --set grafana.enabled=false \
   --set prometheus.enabled=false \
   --set prometheusUrl=http://monitor-prometheus.observability.svc:9090 \
+  --set grafana.externalUrl=https://grafana.example.com \
+  --set dashboard.enforcedHostRegexp=".*" \
   --wait
 
 echo "Deploying Linkerd-Jaeger via Grafana Agent"

--- a/deploy-proxy.sh
+++ b/deploy-proxy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+INGRESS_IP=$(kubectl --context kind-lgtm-central get service \
+  -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+cat <<EOF > haproxy.cfg
+global
+  stats socket /var/run/api.sock user haproxy group haproxy mode 660 level admin expose-fd listeners
+  log stdout format raw local0 info
+
+defaults
+  mode tcp
+  timeout client 10s
+  timeout connect 5s
+  timeout server 10s
+  timeout http-request 10s
+  log global
+
+frontend stats
+  mode http
+  bind *:8404
+  stats enable
+  stats uri /
+  stats refresh 10s
+
+frontend http_external
+  bind *:80
+  default_backend http_workers
+
+frontend https_external
+  bind *:443
+  default_backend https_workers
+
+backend http_workers
+  server ingress ${INGRESS_IP}:80 check
+
+backend https_workers
+  server ingress ${INGRESS_IP}:443 check
+EOF
+
+sudo docker run -d --name haproxy --net kind \
+   -v $(pwd)/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro \
+   -p 80:80 -p 443:443 -p 8404:8404 \
+   haproxytech/haproxy-alpine
+

--- a/remote-agent.yaml
+++ b/remote-agent.yaml
@@ -91,7 +91,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
       - name: grafana-agent
-        image: grafana/agent:v0.38.1
+        image: grafana/agent:v0.39.0
         imagePullPolicy: IfNotPresent
         args:
         - -config.expand-env=true

--- a/values-linkerd.yaml
+++ b/values-linkerd.yaml
@@ -1,7 +1,6 @@
 # Warning: there won't be any resource requests/limits for any Linkerd-related container
 ---
 proxyInit:
-  runAsRoot: true # To avoid issues with privileged DaemonSets like Promtail
   resources:
     cpu:
       limit: ""

--- a/values-loki.yaml
+++ b/values-loki.yaml
@@ -2,9 +2,6 @@
 ---
 fullnameOverride: loki
 
-global:
-  clusterDomain: lgtm-central.cluster.local
-
 serviceAccount: # There is no way to set an account per component
   create: true
   name: loki-sa
@@ -14,16 +11,6 @@ gateway:
 
 test:
   enabled: false
-
-write:
-  affinity: null
-
-read:
-  affinity: null
-  legacyReadTarget: false
-
-backend:
-  affinity: null
 
 loki:
   auth_enabled: true
@@ -87,7 +74,5 @@ monitoring:
     labels:
       release: monitor
   dashboards:
-    namespace: observability
     labels:
       release: monitor
-      grafana_dashboard: "1"

--- a/values-mimir.yaml
+++ b/values-mimir.yaml
@@ -7,8 +7,6 @@ serviceAccount: # There is no way to set an account per component
   name: mimir-sa
 
 global:
-  clusterDomain: lgtm-central.cluster.local
-
   extraEnv:
   - name: JAEGER_ENDPOINT
     value: 'http://grafana-agent.observability.svc:14268/api/traces'
@@ -81,32 +79,31 @@ rollout_operator:
 
 overrides_exporter:
   resources: {}
-  affinity: {}
 
 ruler:
   resources: {}
-  affinity: {}
   initContainers:
   - name: wait-chunks
-    image: busybox
+    image: busybox:1.28
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'until nslookup mimir-chunks-cache.mimir.svc.lgtm-central.cluster.local; do echo waiting for memcached; sleep 1; done']
+    command: ['sh', '-c', 'until nslookup mimir-chunks-cache; do echo waiting for memcached; sleep 1; done']
+  - name: wait-metadata
+    image: busybox:1.28
+    imagePullPolicy: IfNotPresent
+    command: ['sh', '-c', 'until nslookup mimir-metadata-cache; do echo waiting for memcached; sleep 1; done']
 
 alertmanager:
   resources: {}
-  affinity: {}
 
 distributor:
   replicas: 2
   resources: {}
-  affinity: {}
 
 ingester:
   replicas: 3
   persistentVolume:
     size: 20Gi
   resources: {}
-  affinity: {}
   zoneAwareReplication:
     enabled: false
 
@@ -115,27 +112,24 @@ compactor:
   persistentVolume:
     size: 10Gi
   resources: {}
-  affinity: {}
 
 querier:
   replicas: 3
   resources: {}
-  affinity: {}
   initContainers:
   - name: wait-metadata
-    image: busybox
+    image: busybox:1.28
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'until nslookup mimir-metadata-cache.mimir.svc.lgtm-central.cluster.local; do echo waiting for memcached; sleep 1; done']
+    command: ['sh', '-c', 'until nslookup mimir-metadata-cache; do echo waiting for memcached; sleep 1; done']
 
 query_frontend:
   replicas: 2
   resources: {}
-  affinity: {}
   initContainers:
   - name: wait-results
-    image: busybox
+    image: busybox:1.28
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'until nslookup mimir-results-cache.mimir.svc.lgtm-central.cluster.local; do echo waiting for memcached; sleep 1; done']
+    command: ['sh', '-c', 'until nslookup mimir-results-cache; do echo waiting for memcached; sleep 1; done']
 
 query_scheduler:
   enabled: false
@@ -145,18 +139,17 @@ store_gateway:
   persistentVolume:
     size: 10Gi
   resources: {}
-  affinity: {}
   zoneAwareReplication:
     enabled: false
   initContainers:
   - name: wait-metadata
-    image: busybox
+    image: busybox:1.28
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'until nslookup mimir-metadata-cache.mimir.svc.lgtm-central.cluster.local; do echo waiting for memcached; sleep 1; done']
+    command: ['sh', '-c', 'until nslookup mimir-metadata-cache; do echo waiting for memcached; sleep 1; done']
   - name: wait-chunks
-    image: busybox
+    image: busybox:1.28
     imagePullPolicy: IfNotPresent
-    command: ['sh', '-c', 'until nslookup mimir-chunks-cache.mimir.svc.lgtm-central.cluster.local; do echo waiting for memcached; sleep 1; done']
+    command: ['sh', '-c', 'until nslookup mimir-chunks-cache; do echo waiting for memcached; sleep 1; done']
 
 chunks-cache:
   enabled: true
@@ -165,7 +158,6 @@ chunks-cache:
   resources:
     requests:
       cpu: 25m
-  affinity: {}
 
 index-cache:
   enabled: true
@@ -174,7 +166,6 @@ index-cache:
   resources:
     requests:
       cpu: 25m
-  affinity: {}
 
 metadata-cache:
   enabled: true
@@ -183,7 +174,6 @@ metadata-cache:
   resources:
     requests:
       cpu: 25m
-  affinity: {}
 
 results-cache:
   enabled: true
@@ -192,7 +182,6 @@ results-cache:
   resources:
     requests:
       cpu: 25m
-  affinity: {}
 
 metaMonitoring:
   serviceMonitor:
@@ -204,4 +193,10 @@ metaMonitoring:
     enabled: true
     labels:
       release: monitor
-      grafana_dashboard: "1"
+  prometheusRule:
+    enabled: true
+    mimirAlerts: true
+    mimirRules: true
+    labels:
+      release: monitor
+

--- a/values-prometheus-central.yaml
+++ b/values-prometheus-central.yaml
@@ -5,9 +5,15 @@ prometheus:
     - url: http://mimir-distributor.mimir.svc:8080/api/v1/push
       headers:
         X-Scope-OrgID: _local
-
-prometheusOperator:
-  clusterDomain: lgtm-central.cluster.local
+      queueConfig:
+        capacity: 5000
+        minShards: 1
+        maxShards: 50
+        maxSamplesPerSend: 2000
+      writeRelabelConfigs:
+      - sourceLabels: [namespace]
+        regex: "^linkerd.*"
+        action: drop
 
 grafana:
   adminPassword: Adm1nAdm1n

--- a/values-prometheus-common.yaml
+++ b/values-prometheus-common.yaml
@@ -9,6 +9,7 @@ defaultRules:
     etcd: false
     kubeControllerManager: false
     kubeScheduler: false
+    kubeProxy: false
 
 kubeControllerManager:
   enabled: false
@@ -17,6 +18,9 @@ kubeEtcd:
   enabled: false
 
 kubeScheduler:
+  enabled: false
+
+kubeProxy:
   enabled: false
 
 alertmanager: # Required to be notified on alerts managed by Prometheus

--- a/values-prometheus-remote.yaml
+++ b/values-prometheus-remote.yaml
@@ -5,9 +5,15 @@ prometheus:
     - url: http://mimir-distributor-lgtm-central.mimir.svc:8080/api/v1/push
       headers:
         X-Scope-OrgID: remote01
-
-prometheusOperator:
-  clusterDomain: lgtm-remote.cluster.local
+      queueConfig:
+        capacity: 5000
+        minShards: 1
+        maxShards: 50
+        maxSamplesPerSend: 1000
+      writeRelabelConfigs:
+      - sourceLabels: [namespace]
+        regex: "^linkerd.*"
+        action: drop
 
 grafana:
   enabled: false

--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -6,9 +6,6 @@ serviceAccount: # There is no way to set an account per component
   create: true
   name: tempo-sa
 
-global:
-  clusterDomain: lgtm-central.cluster.local
-
 search:
   enabled: true
 
@@ -36,32 +33,26 @@ minio:
   enabled: false
 
 ingester:
-  affinity: '{}'
   topologySpreadConstraints: null
 
 distributor:
   replicas: 2
-  affinity: '{}'
   topologySpreadConstraints: null
 
 queryFrontend:
   replicas: 2
-  affinity: '{}'
   topologySpreadConstraints: null
 
 querier:
   replicas: 3
-  affinity: '{}'
   topologySpreadConstraints: null
 
 compactor:
-  affinity: '{}'
   topologySpreadConstraints: null
 
 metricsGenerator:
   enabled: true
   replicas: 2
-  affinity: '{}'
   topologySpreadConstraints: null
   config:
     processor:
@@ -80,7 +71,6 @@ metricsGenerator:
 
 memcached:
   replicas: 2
-  affinity: '{}'
   topologySpreadConstraints: null
 
 storage:
@@ -99,3 +89,8 @@ metaMonitoring:
     enabled: true
     labels:
       release: monitor
+
+prometheusRule:
+  enabled: true
+  labels:
+    release: monitor


### PR DESCRIPTION
The lab was originally designed with two Kubernetes clusters, each with a single node, using Minikube. However, using Kind is more appropriate, especially in situations where Minikube may not function effectively. It also allows for multiple worker nodes on a cluster, which better replicates a real-world environment.

This solution has been tested on an Intel Mac, running the latest macOS Sonoma, and a Linux server, running the latest Rocky Linux 9.

The way I laid out the solution allows us to switch to a flat multi-cluster setup with Linkerd or replace that with Cilium ClusterMesh and node-level encryption.