### PR TITLE
Use the default topologySpreadConstraints for Tempo.

### DIFF
--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -32,28 +32,18 @@ gateway:
 minio:
   enabled: false
 
-ingester:
-  topologySpreadConstraints: null
-
 distributor:
   replicas: 2
-  topologySpreadConstraints: null
 
 queryFrontend:
   replicas: 2
-  topologySpreadConstraints: null
 
 querier:
   replicas: 3
-  topologySpreadConstraints: null
-
-compactor:
-  topologySpreadConstraints: null
 
 metricsGenerator:
   enabled: true
   replicas: 2
-  topologySpreadConstraints: null
   config:
     processor:
       service_graphs:
@@ -71,7 +61,6 @@ metricsGenerator:
 
 memcached:
   replicas: 2
-  topologySpreadConstraints: null
 
 storage:
   trace:


### PR DESCRIPTION
The default topology constraints defined in the Helm chart apply only to clusters with zone-awareness. If that's not the case, the pods will still be scheduled, so removing them is unnecessary.