### PR TITLE
Switch from OpenTracing to OpenTelemetry for Ingress Nginx.

### DIFF
--- a/remote-agent-config-central.yaml
+++ b/remote-agent-config-central.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   agent.yaml: |
     server:
-      log_level: debug
+      log_level: info
     traces:
       configs:
       - name: kubernetes-traces
@@ -16,7 +16,9 @@ data:
             protocols:
               thrift_http: # For Mimir (port 14268)
           opencensus: # For Linkerd (port 55678)
-          zipkin: # For Nginx Ingress (port 9411)
+          otlp:
+           protocols:
+            grpc: # For Nginx Ingress (port 4317)
         remote_write:
         - endpoint: tempo-distributor.tempo.svc:55680
           insecure: true

--- a/remote-agent-config-remote.yaml
+++ b/remote-agent-config-remote.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   agent.yaml: |
     server:
-      log_level: debug
+      log_level: info
     traces:
       configs:
       - name: kubernetes-traces

--- a/values-ingress.yaml
+++ b/values-ingress.yaml
@@ -21,7 +21,18 @@ controller:
       maxUnavailable: 1
   service:
     externalTrafficPolicy: Local
+  opentelemetry:
+    enabled: true
   config:
-    enable-opentracing: "true"
-    zipkin-collector-host: grafana-agent.observability.svc
-    zipkin-service-name: nginx-internal
+    enable-opentelemetry: "true"
+    opentelemetry-trust-incoming-span: "false"
+    opentelemetry-operation-name: HTTP $request_method $service_name $location_path
+    otlp-collector-host: grafana-agent.observability.svc
+    otel-service-name: nginx-internal
+    otel-sampler: AlwaysOn
+    otel-sampler-ratio: "1.0"
+    http-snippet: |
+      # For Linkerd compatibility - https://linkerd.io/2.14/tasks/distributed-tracing/#troubleshooting
+      opentelemetry_propagate b3;
+      # https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/#http-server-semantic-conventions
+      opentelemetry_attribute "http.route" "$service_name:$location_path";


### PR DESCRIPTION
OpenTracing was deprecated in favor of OpenTelemetry. 

The PoC uses Nginx only for Grafana, but it shows how to use OpenTelemetry correctly with Linkerd compatibility in mind.