### PR TITLE
Use single-instance Deployment for Grafana Agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We will use Grafana Agent to send traces to Tempo on all environments to have mu
 
 We will use Promtail to send logs to Loki on all environments deployed as a `DaemonSet`.
 
-We will use Prometheus to send metrics to Mimir on all environments.
+We will use Prometheus to send metrics to Mimir on all environments (handling `ServiceMonitor` and `PodMonitor` resources).
 
 We will have *two* Kubernetes clusters, one with the LGTM Stack exposing Grafana via Ingress (`lgtm-central`), and another with a sample application, generating metrics, logs, and traces (`lgtm-remote`).
 
@@ -46,7 +46,7 @@ The following is the list of Data Sources on the Central Grafana:
 
 ## Requirements
 
-* [Docker](https://www.docker.com/) ([OrbStack](https://orbstack.dev/) recommend if you're on macOS)
+* [Docker](https://www.docker.com/) ([OrbStack](https://orbstack.dev/) recommended when running on macOS)
 * [Kubectl](https://kubernetes.io/docs/tasks/tools/)
 * [Kind](https://kind.sigs.k8s.io/)
 * [Helm](https://helm.sh/)

--- a/grafana-agent-config-central.yaml
+++ b/grafana-agent-config-central.yaml
@@ -11,6 +11,9 @@ data:
     traces:
       configs:
       - name: kubernetes-traces
+        batch:
+          send_batch_size: 1000
+          timeout: 5s
         receivers:
           jaeger:
             protocols:

--- a/grafana-agent-config-remote.yaml
+++ b/grafana-agent-config-remote.yaml
@@ -11,6 +11,9 @@ data:
     traces:
       configs:
       - name: kubernetes-traces
+        batch:
+          send_batch_size: 1000
+          timeout: 5s
         receivers:
           jaeger:
             protocols:

--- a/values-agent.yaml
+++ b/values-agent.yaml
@@ -1,4 +1,6 @@
 # Warning: there won't be any resource requests/limits for any grafana agent-related container
+# To use more than one replica, follow load balancing examples from the documentation:
+# https://grafana.com/docs/agent/latest/static/set-up/deploy-agent/
 ---
 agent:
   mode: static
@@ -30,9 +32,7 @@ agent:
     port: 4318
     targetPort: 4318
 controller:
-  tolerations:
-  - effect: NoSchedule
-    operator: Exists
+  type: deployment
 serviceMonitor:
   enabled: true
   additionalLabels:


### PR DESCRIPTION
In this PoC, Grafana Agent only forwards traces to Tempo. The most effortless use case is having a single instance because using more than one requires a unique configuration to ensure that all the traces and spans are correctly handled.

There is no need for that use case here, so I ended up having something similar to the initial approach but using the Helm chart.