### PR TITLE
Improve configuration for LGTM components

### DIFF
--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -14,7 +14,7 @@ CLUSTER_ID=${CLUSTER_ID-1}
 POD_CIDR=${POD_CIDR-10.244.0.0/16}
 SVC_CIDR=${SVC_CIDR-10.96.0.0/12}
 MASTER=${CONTEXT}-control-plane
-CILIUM_VERSION=${CILIUM_VERSION-1.15.1}
+CILIUM_VERSION=${CILIUM_VERSION-1.15.2}
 HOST_IP=${HOST_IP-127.0.0.1} # The IP address of your machine to expose API Server (don't change when using OrbStack)
 
 # Abort if the cluster exists; if so, ensure the kubeconfig is exported

--- a/values-loki.yaml
+++ b/values-loki.yaml
@@ -19,7 +19,8 @@ loki:
   commonConfig: null
   structuredConfig:
     ruler:
-      alertmanager_url: http://monitor-alertmanager:9093
+      alertmanager_url: http://monitor-alertmanager.observability.svc:9093
+      enable_alertmanager_v2: true
       enable_sharding: true
       storage:
         type: s3

--- a/values-mimir.yaml
+++ b/values-mimir.yaml
@@ -37,10 +37,6 @@ mimir:
       instance_limits:
         max_ingestion_rate: 30000 # Per-distributor rate limit
         max_inflight_push_requests: 250
-    ingester:
-      ring:
-        num_tokens: 512
-        unregister_on_shutdown: false
     frontend:
       log_queries_longer_than: 1m
     limits:
@@ -52,6 +48,8 @@ mimir:
       # https://grafana.com/docs/mimir/latest/operators-guide/configure/configure-out-of-order-samples-ingestion/
       out_of_order_time_window: 15m
       max_cache_freshness: 15m
+    ruler:
+      alertmanager_url: http://monitor-alertmanager.observability.svc:9093
     blocks_storage:
       s3:
         bucket_name: mimir-data
@@ -60,7 +58,7 @@ mimir:
         bucket_name: mimir-ruler
     alertmanager_storage:
       s3:
-        bucket_name: mimir-ruler
+        bucket_name: mimir-alerts
 
 runtimeConfig:
   ingester_limits:

--- a/values-minio.yaml
+++ b/values-minio.yaml
@@ -44,6 +44,10 @@ buckets:
   policy: none
   purge: false
   versioning: false
+- name: mimir-alerts
+  policy: none
+  purge: false
+  versioning: false
 
 postJob:
   podAnnotations:

--- a/values-prometheus-central.yaml
+++ b/values-prometheus-central.yaml
@@ -1,6 +1,7 @@
 ---
 prometheus:
   prometheusSpec:
+    enableRemoteWriteReceiver: true # For Tempo Metrics Generator
     remoteWrite:
     - url: http://mimir-distributor.mimir.svc:8080/api/v1/push
       headers:
@@ -60,7 +61,6 @@ grafana:
             datasourceUid: loki_remote_tns_ds
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: remote01
       - name: Loki Remote TNS
@@ -78,7 +78,6 @@ grafana:
             url: $${__value.raw}
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: remote01
       - name: Mimir Remote TNS
@@ -91,7 +90,6 @@ grafana:
         jsonData:
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: remote01
       - name: Tempo Remote OTEL
@@ -112,7 +110,6 @@ grafana:
             datasourceUid: loki_remote_otel_ds
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: remote02
       - name: Loki Remote OTEL
@@ -130,7 +127,6 @@ grafana:
             url: $${__value.raw}
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: remote02
       - name: Mimir Remote OTEL
@@ -143,7 +139,6 @@ grafana:
         jsonData:
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: remote02
       - name: Tempo Local
@@ -164,7 +159,6 @@ grafana:
             datasourceUid: loki_ds
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: _local
       - name: Loki Local
@@ -182,7 +176,6 @@ grafana:
             url: $${__value.raw}
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: _local
       - name: Mimir Local
@@ -195,7 +188,6 @@ grafana:
         jsonData:
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
-          manageAlerts: false
         secureJsonData:
           httpHeaderValue1: _local
   dashboardProviders:

--- a/values-prometheus-common.yaml
+++ b/values-prometheus-common.yaml
@@ -59,11 +59,10 @@ prometheus:
     create: true
     name: prometheus-sa
   prometheusSpec:
-    enableRemoteWriteReceiver: true # For Tempo Metrics Generator
     enableFeatures:
     - exemplar-storage
     scrapeInterval: 30s
-    retention: 30d
+    retention: 7d
     resources: null
     storageSpec:
       volumeClaimTemplate:


### PR DESCRIPTION
* Fixed Alertmanager URL for Loki, as it should point to the one running in the `observability` namespace.
* Removed Ingester settings from Mimir configuration, as all those values are part of the current defaults.
* Fixed bucket name for alerts on Mimir.
* Added the external Alertmanager URL for the Mimir Ruler (for now the internal one is not deployed).
* Remove `manageAlerts` from the data sources definitions for Grafana (we want to use them when possible).
* Reduce the retention of Prometheus to 7 days (data is forwarded to Mimir).

Bonus:

* Upgraded Cilium to 1.15.2