### PR TITLE
Improve configuration for LGTM components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.key
 cert-expiry-date.txt
 haproxy.cfg
+experiments
 TODO.md

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ kubectl get svc --context kind-lgtm-central -n ingress-nginx ingress-nginx-contr
 If you're using Docker for Desktop on macOS, I created a script to deploy HAProxy which allows you to access the Ingress Service via localhost:
 
 ```bash
-./deploy-proxy
+./deploy-proxy.sh
 ```
 
 In that case, use `127.0.0.1` when modifying `/etc/hosts` instead of the LB IP.

--- a/deploy-central.sh
+++ b/deploy-central.sh
@@ -84,13 +84,12 @@ helm upgrade --install mimir grafana/mimir-distributed \
 kubectl rollout status -n mimir deployment/mimir-distributor
 kubectl rollout status -n mimir deployment/mimir-query-frontend
 
+echo "Create Ingress resources"
+kubectl apply -f ingress-central.yaml
+
 echo "Deploying Nginx Ingress Controller"
 helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
   -n ingress-nginx --create-namespace -f values-ingress.yaml --wait
-sleep 10 # Give some extra time to avoid issues with ingress webhooks
-
-echo "Create Ingress resources"
-kubectl apply -f ingress-central.yaml
 
 echo "Exporting Services via Linkerd Multicluster"
 kubectl -n tempo label service/tempo-distributor mirror.linkerd.io/exported=true

--- a/values-loki.yaml
+++ b/values-loki.yaml
@@ -1,51 +1,37 @@
 # Warning: there won't be any resource requests/limits for any Loki-related container
 ---
-fullnameOverride: loki
-
 serviceAccount: # There is no way to set an account per component
   create: true
   name: loki-sa
-
-gateway:
-  enabled: false
 
 test:
   enabled: false
 
 loki:
   auth_enabled: true
+  commonConfig:
+    path_prefix: /var/loki
   storage:
     type: s3
-  commonConfig: null
-  structuredConfig:
-    ruler:
-      alertmanager_url: http://monitor-alertmanager.observability.svc:9093
-      enable_alertmanager_v2: true
-      enable_sharding: true
-      storage:
-        type: s3
-        s3:
-          bucketnames: loki-ruler
-          insecure: true
-          s3forcepathstyle: true
-    common:
-      path_prefix: /var/loki
-      storage:
-        s3:
-          endpoint: minio.storage.svc:9000
-          bucketnames: loki-data
-          access_key_id: remote_user
-          secret_access_key: R3m0t3us3r
-          insecure: true
-          s3forcepathstyle: true
-  limits_config:
-    ingestion_rate_mb: 10
+    s3:
+      endpoint: minio.storage.svc:9000
+      accessKeyId: remote_user
+      secretAccessKey: R3m0t3us3r
+      insecure: true
+      s3ForcePathStyle: true
+    bucketNames:
+      chunks: loki-data
+      ruler: loki-ruler
   storage_config:
     tsdb_shipper:
       active_index_directory: /var/loki/tsdb-shipper-active
       cache_location: /var/loki/tsdb-shipper-cache
       cache_ttl: 24h
       shared_store: s3
+  rulerConfig:
+    alertmanager_url: http://monitor-alertmanager.observability.svc:9093
+    enable_alertmanager_v2: true
+    enable_sharding: true
   schemaConfig:
     configs:
     - from: '2024-02-01'
@@ -55,6 +41,17 @@ loki:
       index:
         period: 24h
         prefix: loki_index_
+  limits_config:
+    ingestion_rate_mb: 10
+    retention_period: 2h
+  ingester:
+    max_chunk_age: 30m
+  compactor:
+    working_directory: /var/loki/compactor
+    shared_store: s3
+    retention_enabled: true
+    delete_request_cancel_period: 5m
+    retention_delete_delay: 5m
 
 monitoring:
   selfMonitoring:

--- a/values-mimir.yaml
+++ b/values-mimir.yaml
@@ -1,7 +1,5 @@
 # Warning: there won't be any resource requests/limits for any Mimir-related container
 ---
-fullnameOverride: mimir
-
 serviceAccount: # There is no way to set an account per component
   create: true
   name: mimir-sa
@@ -44,10 +42,17 @@ mimir:
       max_global_series_per_user: 1000000 # To accomodate one big tenant
       max_global_series_per_metric: 100000
       max_label_names_per_series: 100
+      cardinality_analysis_enabled: true
+      compactor_blocks_retention_period: 2h
       # Allow ingestion of out-of-order samples up to 15 minutes since the latest received sample for the series.
       # https://grafana.com/docs/mimir/latest/operators-guide/configure/configure-out-of-order-samples-ingestion/
       out_of_order_time_window: 15m
       max_cache_freshness: 15m
+    compactor:
+      block_ranges:
+      - 30m
+      - 1h
+      - 2h
     ruler:
       alertmanager_url: http://monitor-alertmanager.observability.svc:9093
     blocks_storage:
@@ -66,8 +71,8 @@ runtimeConfig:
     max_ingestion_rate: 30000
     max_series: 1000000
 
-nginx:
-  enabled: false
+gateway:
+  enabledNonEnterprise: true
 
 minio:
   enabled: false
@@ -130,7 +135,7 @@ query_frontend:
     command: ['sh', '-c', 'until nslookup mimir-results-cache; do echo waiting for memcached; sleep 1; done']
 
 query_scheduler:
-  enabled: false
+  replicas: 2
 
 store_gateway:
   replicas: 3
@@ -184,7 +189,6 @@ results-cache:
 metaMonitoring:
   serviceMonitor:
     enabled: true
-    clusterLabel: central
     labels:
       release: monitor
   dashboards:

--- a/values-prometheus-central.yaml
+++ b/values-prometheus-central.yaml
@@ -67,7 +67,7 @@ grafana:
         type: loki
         uid: loki_remote_tns_ds
         access: proxy
-        url: http://loki-read.loki.svc:3100
+        url: http://loki-gateway.loki.svc
         isDefault: false
         editable: true
         jsonData:
@@ -86,7 +86,7 @@ grafana:
         isDefault: false
         editable: true
         access: proxy
-        url: http://mimir-query-frontend.mimir.svc:8080/prometheus
+        url: http://mimir-gateway.mimir.svc/prometheus
         jsonData:
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
@@ -116,7 +116,7 @@ grafana:
         type: loki
         uid: loki_remote_otel_ds
         access: proxy
-        url: http://loki-read.loki.svc:3100
+        url: http://loki-gateway.loki.svc
         isDefault: false
         editable: true
         jsonData:
@@ -135,7 +135,7 @@ grafana:
         isDefault: false
         editable: true
         access: proxy
-        url: http://mimir-query-frontend.mimir.svc:8080/prometheus
+        url: http://mimir-gateway.mimir.svc/prometheus
         jsonData:
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST
@@ -165,7 +165,7 @@ grafana:
         type: loki
         uid: loki_ds
         access: proxy
-        url: http://loki-read.loki.svc:3100
+        url: http://loki-gateway.loki.svc
         isDefault: false
         editable: true
         jsonData:
@@ -184,7 +184,7 @@ grafana:
         isDefault: false
         editable: true
         access: proxy
-        url: http://mimir-query-frontend.mimir.svc:8080/prometheus
+        url: http://mimir-gateway.mimir.svc/prometheus
         jsonData:
           httpHeaderName1: X-Scope-OrgID
           httpMethod: POST

--- a/values-prometheus-common.yaml
+++ b/values-prometheus-common.yaml
@@ -37,6 +37,10 @@ alertmanager: # Required to be notified on alerts managed by Prometheus
             requests:
               storage: 1Gi
 
+prometheus-node-exporter:
+  podAnnotations:
+    linkerd.io/inject: enabled
+
 prometheusOperator:
   serviceAccount:
     create: true

--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -1,7 +1,5 @@
 # Warning: there won't be any resource requests/limits for any Tempo-related container
 ---
-fullnameOverride: tempo
-
 serviceAccount: # There is no way to set an account per component
   create: true
   name: tempo-sa
@@ -15,6 +13,11 @@ tempo:
       reporting_enabled: false
 
 multitenancyEnabled: true
+
+compactor:
+  config:
+    compaction:
+      block_retention: 2h
 
 traces:
   otlp:


### PR DESCRIPTION
* Refactor Loki configuration to be more aligned with the Helm chart design.
* Add 2 hours of retention for Loki, Tempo, and Mimir.
* Add labels to worker nodes to emulate having different availability zones (to be able to test zone-awareness replication).
* Fix the `deploy-proxy.sh` link on the README.
* Deploy the cert-manager and Ingress resources before the Ingress Controller to avoid race conditions.
* Remote `fullnameOverride` from Loki, Tempo, and Mimir, as it is unnecessary and could confuse dashboard logic.
* Enable gateway for Mimir and Loki (to access the Ruler API from the Grafana data sources) and fix all references in Grafana.
* Enable query scheduler on Mimir (as it is by default).
* Removing `clusterLabel` from Mimir meta-monitoring, as it is unnecessary and could confuse dashboard logic.