### PR TITLE
Fix/Improve OTEL Demo configuration.

### DIFF
--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -61,20 +61,3 @@ echo "Deploying OpenTelemetry Demo application"
 helm upgrade --install demo open-telemetry/opentelemetry-demo \
   -n otel -f values-opentelemetry-demo.yaml
 kubectl rollout status -n otel daemonset/demo-otelcol-agent
-
-cat <<EOF | kubectl apply -f -
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: demo-otelcol
-  namespace: otel
-  labels:
-    release: monitor
-spec:
-  endpoints:
-  - path: /metrics
-    port: metrics
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: otelcol
-EOF

--- a/values-opentelemetry-demo.yaml
+++ b/values-opentelemetry-demo.yaml
@@ -6,7 +6,7 @@ default:
 opentelemetry-collector:
   image:
     tag: latest
-  mode: daemonset
+  mode: deployment
   presets:
     logsCollection:
       enabled: true
@@ -35,16 +35,21 @@ opentelemetry-collector:
           insecure: true # Linkerd uses mTLS behind the scenes
         headers:
           X-Scope-OrgID: remote02
-    processors:
-      spanmetrics:
-        metrics_exporter: prometheusremotewrite
     service:
-      extensions: [ health_check, memory_ballast ]
+      extensions:
+      - health_check
+      - memory_ballast
       pipelines:
         metrics:
-          exporters: [ prometheusremotewrite ]
+          receivers:
+          - otlp
+          - spanmetrics
+          - prometheus
+          exporters:
+          - prometheusremotewrite
         logs:
-          exporters: [ loki ]
+          exporters:
+          - loki
 
 jaeger:
   enabled: false


### PR DESCRIPTION
Initially, I was deploying the OTEL Collector as `DaemonSet`, but I changed it to `Deployment` to experiment with Tail Sampling in the future (for now, with a single replica).

I also simplified the configuration to let OTEL export its metrics via Remote Write instead of having Prometheus do it.

Note: you can test it without deploying the whole solution. Ensure you update the URLs on `values-opentelemetry-demo.yaml` to point to the local Mimir, Tempo, and Loki.