### PR TITLE
Improve alertmanager and LGTM settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Status check results are √
 ```bash
 ➜  linkerd mc gateways --context kind-lgtm-remote
 CLUSTER       ALIVE    NUM_SVC      LATENCY
-lgtm-central  True           3          2ms
+lgtm-central  True           4          2ms
 ```
 
 When linking `lgtm-remote` to `lgtm-central` via Linkerd Multi-Cluster, the CLI will use the Kubeconfig from the `lgtm-central` to configure the service mirror controller on the `lgtm-remote` cluster.

--- a/deploy-central.sh
+++ b/deploy-central.sh
@@ -95,6 +95,7 @@ echo "Exporting Services via Linkerd Multicluster"
 kubectl -n tempo label service/tempo-distributor mirror.linkerd.io/exported=true
 kubectl -n mimir label service/mimir-distributor mirror.linkerd.io/exported=true
 kubectl -n loki label service/loki-write mirror.linkerd.io/exported=true
+kubectl -n observability label service/monitor-alertmanager mirror.linkerd.io/exported=true
 
 # Update DNS
 INGRESS_IP=$(kubectl get service -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

--- a/values-loki.yaml
+++ b/values-loki.yaml
@@ -43,9 +43,11 @@ loki:
         prefix: loki_index_
   limits_config:
     ingestion_rate_mb: 10
-    retention_period: 2h
+    retention_period: 7d # Global Metrics TTL
   ingester:
-    max_chunk_age: 30m
+    max_chunk_age: 1h
+  querier:
+    query_ingesters_within: 2h
   compactor:
     working_directory: /var/loki/compactor
     shared_store: s3

--- a/values-mimir.yaml
+++ b/values-mimir.yaml
@@ -37,25 +37,31 @@ mimir:
         max_inflight_push_requests: 250
     frontend:
       log_queries_longer_than: 1m
+    querier:
+      query_store_after: 3h # < query_ingesters_within
     limits:
       ingestion_rate: 30000 # Per-user rate limit
       max_global_series_per_user: 1000000 # To accomodate one big tenant
       max_global_series_per_metric: 100000
       max_label_names_per_series: 100
       cardinality_analysis_enabled: true
-      compactor_blocks_retention_period: 2h
-      # Allow ingestion of out-of-order samples up to 15 minutes since the latest received sample for the series.
+      compactor_blocks_retention_period: 7d # Global Metrics TTL
+      query_ingesters_within: 4h # > query_store_after
+      # Allow ingestion of out-of-order samples up to X minutes since the latest received sample for the series.
       # https://grafana.com/docs/mimir/latest/operators-guide/configure/configure-out-of-order-samples-ingestion/
       out_of_order_time_window: 15m
       max_cache_freshness: 15m
     compactor:
       block_ranges:
-      - 30m
       - 1h
       - 2h
+      - 4h
+      - 24h
     ruler:
       alertmanager_url: http://monitor-alertmanager.observability.svc:9093
     blocks_storage:
+      tsdb:
+        retention_period: 6h # > query_store_after
       s3:
         bucket_name: mimir-data
     ruler_storage:
@@ -95,7 +101,7 @@ ruler:
     imagePullPolicy: IfNotPresent
     command: ['sh', '-c', 'until nslookup mimir-metadata-cache; do echo waiting for memcached; sleep 1; done']
 
-alertmanager:
+alertmanager: # Unused for now
   resources: {}
 
 distributor:

--- a/values-prometheus-central.yaml
+++ b/values-prometheus-central.yaml
@@ -1,4 +1,19 @@
 ---
+alertmanager: # Required to be notified on alerts managed by Prometheus
+  enabled: true
+  serviceAccount:
+    create: true
+    name: alertmanager-sa
+  alertmanagerSpec:
+    resources: null
+    storage:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 1Gi
+
 prometheus:
   prometheusSpec:
     enableRemoteWriteReceiver: true # For Tempo Metrics Generator
@@ -17,6 +32,7 @@ prometheus:
         action: drop
 
 grafana:
+  enabled: true
   adminPassword: Adm1nAdm1n
   serviceAccount:
     create: true

--- a/values-prometheus-common.yaml
+++ b/values-prometheus-common.yaml
@@ -6,6 +6,7 @@ cleanPrometheusOperatorObjectNames: true
 
 defaultRules:
   rules:
+    alertmanager: false
     etcd: false
     kubeControllerManager: false
     kubeScheduler: false
@@ -23,19 +24,11 @@ kubeScheduler:
 kubeProxy:
   enabled: false
 
-alertmanager: # Required to be notified on alerts managed by Prometheus
-  serviceAccount:
-    create: true
-    name: alertmanager-sa
-  alertmanagerSpec:
-    resources: null
-    storage:
-      volumeClaimTemplate:
-        spec:
-          accessModes: ["ReadWriteOnce"]
-          resources:
-            requests:
-              storage: 1Gi
+alertmanager:
+  enabled: false
+
+grafana:
+  enabled: false
 
 prometheus-node-exporter:
   podAnnotations:

--- a/values-prometheus-remote-otel.yaml
+++ b/values-prometheus-remote-otel.yaml
@@ -14,6 +14,9 @@ prometheus:
       - sourceLabels: [namespace]
         regex: "^linkerd.*"
         action: drop
-
-grafana:
-  enabled: false
+    alertingEndpoints:
+    - name: monitor-alertmanager-lgtm-central
+      namespace: observability
+      port: 9093
+      pathPrefix: "/"
+      apiVersion: v2

--- a/values-prometheus-remote.yaml
+++ b/values-prometheus-remote.yaml
@@ -14,6 +14,9 @@ prometheus:
       - sourceLabels: [namespace]
         regex: "^linkerd.*"
         action: drop
-
-grafana:
-  enabled: false
+    alertingEndpoints:
+    - name: monitor-alertmanager-lgtm-central
+      namespace: observability
+      port: 9093
+      pathPrefix: "/"
+      apiVersion: v2

--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -17,7 +17,7 @@ multitenancyEnabled: true
 compactor:
   config:
     compaction:
-      block_retention: 2h
+      block_retention: 48h # Global Metrics TTL
 
 traces:
   otlp:
@@ -40,6 +40,11 @@ distributor:
 
 queryFrontend:
   replicas: 2
+  config:
+    search:
+      # The following are defaults but show how to control where to query
+      query_backend_after: 15m
+      query_ingesters_until: 30m
 
 querier:
   replicas: 3


### PR DESCRIPTION
* Restoring retention settings to more realistic values.
* Improve the Alerrmanager configuration to promote usage of the central instance (still using the external one).
* Explicitly add query ranges for Ingesters to let users know when to query internal Ingester files or go to block storage when querying for data.
* Improve OTEL Collector to send its metrics directly to Mimir via Remote Write instead of using ServiceMonitor (to make it more independent from an external Prometheus).