### PR TITLE
Collect statistics from Grafana.

### DIFF
--- a/values-prometheus-central.yaml
+++ b/values-prometheus-central.yaml
@@ -55,6 +55,10 @@ grafana:
       enable: tempoSearch tempoBackendSearch tempoApmTable traceqlEditor
     server:
       domain: grafana.example.com # Ensure to use the correct domain / Will be used for Ingress
+  serviceMonitor:
+    enabled: true
+    labels:
+      release: monitor
   datasources:
     datasources.yaml:
       apiVersion: 1


### PR DESCRIPTION
By default, as Grafana is a sub-chart of the Prometheus Kube Stack, the `release` label is not added to the `ServiceMonitor` by default, so this PR solves this issue.