### PR TITLE
Cleanup and improve OTEL Collector configuration.

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -25,9 +25,11 @@ kubectl --context kind-lgtm-central label cm tns -n observability grafana_dashbo
 
 ## OTEL Demo Application
 
-Some of the [original](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo/grafana-dashboards) dashboards assume the presence of a local Prometheus data source as the default, and others use an OpenSearch data source, which won't work when deploying them at the central location. The provided dashboards were adjusted to work on this environment.
+> *WARNING:* Consider the following a work in progress.
 
-The following deploys the dashboards from the OTEL Demo Helm Chart:
+Some of the [original](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-demo/grafana-dashboards) dashboards assume a local Prometheus data source as the default, and others use an OpenSearch data source, which won't work when deploying them at the central location. This is mainly because the OTEL Demo deploys Prometheus and Grafana by default, but we're not using those instances in this PoC.
+
+The following deploys adjusted versions of the dashboards from the OTEL Demo Helm Chart to work on this environment:
 
 ```bash
 kubectl --context kind-lgtm-central create cm otel-demo -n observability \
@@ -37,5 +39,3 @@ kubectl --context kind-lgtm-central create cm otel-demo -n observability \
   --from-file=otel-collector-flow.json
 kubectl --context kind-lgtm-central label cm otel-demo -n observability grafana_dashboard=1 
 ```
-
-> Doing that manually is because we're not deploying Grafana with the OTEL Demo App. Instead, we have it on the central cluster.

--- a/values-opentelemetry-demo.yaml
+++ b/values-opentelemetry-demo.yaml
@@ -35,21 +35,41 @@ opentelemetry-collector:
           insecure: true # Linkerd uses mTLS behind the scenes
         headers:
           X-Scope-OrgID: remote02
+    processors:
+      tail_sampling:
+        policies:
+          [
+            {
+              name: errors-policy,
+              type: status_code,
+              status_code: { status_codes: [ERROR] },
+            },
+            {
+              name: randomized-policy,
+              type: probabilistic,
+              probabilistic: { sampling_percentage: 30 },
+            },
+          ]
     service:
-      extensions:
-      - health_check
-      - memory_ballast
       pipelines:
         metrics:
           receivers:
           - otlp
-          - spanmetrics
           - prometheus
           exporters:
           - prometheusremotewrite
         logs:
           exporters:
           - loki
+        traces:
+          processors:
+          - k8sattributes
+          - memory_limiter
+          - resource
+          - tail_sampling
+          - batch
+          exporters:
+          - otlp
 
 jaeger:
   enabled: false
@@ -65,6 +85,10 @@ opensearch:
 
 components:
   featureflagService:
+    resources:
+      limits:
+        memory: null
+  loadgenerator:
     resources:
       limits:
         memory: null


### PR DESCRIPTION
* As we're using the metrics generator in Tempo, there is no need to have the same behavior inside the OTEL Collector, so I turned it off.
* I added the example configuration for the Tail Sampling to showcase how it works.
* I updated the documentation for the Demo Dashboards as they are not working fully.
* Memory restrictions were removed for the load generator as several OOMKilled.

I noticed some metric names were modified, although I am still determining where. The names differed on earlier versions of the OTEL collector.

I used the following two PromQL to visualize the difference between incoming spans and exported spans:
```
sum(rate(otelcol_receiver_accepted_spans_total[5m]))
sum(rate(otelcol_exporter_sent_spans_total[5m]))
```
> Older versions don't have the suffix `_total`, see [here](https://opentelemetry.io/docs/demo/collector-data-flow-dashboard/).