### PR TITLE
Apply several improvements

### DIFF
--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -14,7 +14,7 @@ CLUSTER_ID=${CLUSTER_ID-1}
 POD_CIDR=${POD_CIDR-10.244.0.0/16}
 SVC_CIDR=${SVC_CIDR-10.96.0.0/12}
 MASTER=${CONTEXT}-control-plane
-CILIUM_VERSION=${CILIUM_VERSION-1.15.2}
+CILIUM_VERSION=${CILIUM_VERSION-1.15.3}
 HOST_IP=${HOST_IP-127.0.0.1} # The IP address of your machine to expose API Server (don't change when using OrbStack)
 
 # Abort if the cluster exists; if so, ensure the kubeconfig is exported

--- a/values-mimir.yaml
+++ b/values-mimir.yaml
@@ -1,5 +1,8 @@
 # Warning: there won't be any resource requests/limits for any Mimir-related container
 ---
+image:
+  tag: 2.12.0 # Force latest version until the chart is updated
+
 serviceAccount: # There is no way to set an account per component
   create: true
   name: mimir-sa
@@ -86,6 +89,7 @@ overrides_exporter:
   resources: {}
 
 ruler:
+  replicas: 2
   resources: {}
   initContainers:
   - name: wait-chunks

--- a/values-opentelemetry-demo.yaml
+++ b/values-opentelemetry-demo.yaml
@@ -1,13 +1,13 @@
 ---
 opentelemetry-collector:
-  mode: deployment
+  mode: daemonset
   resources:
     limits:
       memory: 512Mi
   presets:
     logsCollection:
       enabled: true
-      includeCollectorLogs: false
+      includeCollectorLogs: true
   service:
     enabled: true
   config:

--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -89,8 +89,3 @@ metaMonitoring:
     enabled: true
     labels:
       release: monitor
-
-prometheusRule:
-  enabled: true
-  labels:
-    release: monitor


### PR DESCRIPTION
- Configure the OTEL collector to forward pod logs (including its own). This includes deploy as DaemonSet instead of Deployment.
- Improve script to import Tempo Mixins.
- Upgrade Mimir to 2.12.0.
- Upgrade Cilium to 1.15.3.
- Remove unnecessary content from Tempo values file.