### PR TITLE
Fix OTEL-Col validation and force Loki version.

### DIFF
--- a/deploy-central.sh
+++ b/deploy-central.sh
@@ -66,7 +66,7 @@ helm upgrade --install tempo grafana/tempo-distributed \
   -n tempo -f values-tempo.yaml --set global.clusterDomain=$DOMAIN --wait
 
 echo "Deploying Grafana Loki"
-helm upgrade --install loki grafana/loki \
+helm upgrade --install loki grafana/loki --version 5.47.2 \
   -n loki -f values-loki.yaml --set global.clusterDomain=$DOMAIN --wait
 
 echo "Deploying Grafana Promtail (for Logs)"

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -60,4 +60,4 @@ helm upgrade --install monitor prometheus-community/kube-prometheus-stack \
 echo "Deploying OpenTelemetry Demo application"
 helm upgrade --install demo open-telemetry/opentelemetry-demo \
   -n otel -f values-opentelemetry-demo.yaml
-kubectl rollout status -n otel daemonset/demo-otelcol-agent
+kubectl rollout status -n otel deployment/demo-otelcol


### PR DESCRIPTION
The new Loki 3.0.0 was released with a new major version of the Helm chart (6.0.0), which is incompatible with the current structure of this PoC. Therefore, I'm enforcing the latest version of the chart that works until I apply the changes to use the new version.

I'm also fixing the logic on the script after deploying the OTEL demo due to the restore of using a Deployment instead of a DaemonSet that I forgot to fix.