### PR TITLE
Add the ability to replace Linkerd with Cilium ClusterMesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In the first scenario, we have Prometheus collecting data from the Kubernetes cl
 
 In the second scenario, we have Grafana Agent either on [static](https://grafana.com/docs/agent/latest/static/) or [flow](https://grafana.com/docs/agent/latest/flow/) mode handling all the observability data (metrics, logs, and traces) and forward it to the LGTM stack.
 
-In the third scenario, we have Prometheus handling the cluster metrics and the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) handling metrics, logs, and traces via OTLP from the applications running in the cluster and forwarding the data to the central LGTM stack.
+In the third scenario, we have Prometheus handling the cluster metrics and the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) handling metrics, logs, and traces received via OTLP from the applications running in the cluster and forwarding the data to the central LGTM stack.
 
 Each cluster (including the central one) will be a tenant on Mimir, Loki, and Tempo to separate the data from each other.
 
@@ -45,6 +45,14 @@ The Multi-Cluster Link is originated on the Remote Cluster, targeting the Centra
 Each remote cluster would be a Tenant in terms of Mimir, Tempo and Loki. For demo purposes, Grafana has Data Sources to get data from the Local components and Remote components.
 
 Mimir supports Tenant Federation if you need to look at metrics from different tenants simultaneously.
+
+As Cilium is available on each cluster, and the scripts are arranged in a way that there won't be IP Address collisions between all the clusters (for Pod and Services), it is possible to replace Linkerd with Cilium [ClusterMesh](https://cilium.io/use-cases/cluster-mesh/) with Encryption enabled. We will be using [Wireguard](https://www.wireguard.com/) as it is easier to deploy than IPSec and will encrypt the communication between worker nodes and clusters. The difference between Cilium and Linkerd is that Pod-to-Pod communication won't be encrypted when the instances run in the same worker node, and mTLS won't be involved.
+
+If you want to use Cilium ClusterMesh instead of Linkerd, run the following before deploying the clusters:
+
+```bash
+export CILIUM_CLUSTER_MESH_ENABLED=yes
+```
 
 > **WARNING:** There will be several worker nodes between both clusters, so we recommend having a machine with 8 Cores and 32GB of RAM to deploy the lab, or you would have to make manual adjustments. I choose `kind` instead of `minikube` as I feel the performance is better; having multiple nodes is more manageable and works better on ARM-based Macs. All the work done here was tested on an Intel-based Mac running [OrbStack](https://orbstack.dev/) instead of Docker Desktop and on a Linux Server running Rocky Linux 9. It is worth noticing that OrbStack outperforms Docker Desktop and allows you to access all containers and IPs (which also applies to Kubernetes services) as if you were running on Linux.
 

--- a/deploy-certs.sh
+++ b/deploy-certs.sh
@@ -43,4 +43,11 @@ step certificate create \
   --ca ca.crt --ca-key ca.key \
   --force
 
+step certificate create \
+  root.cilium.io \
+  cilium-ca.crt cilium-ca.key \
+  --profile root-ca \
+  --no-password --insecure \
+  --force
+
 echo ${CERT_EXPIRY_DATE} > cert-expiry-date.txt

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -31,7 +31,7 @@ if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
 fi
 
 # Abort if the cluster exists; if so, ensure the kubeconfig is exported
-if [[ $(kind get clusters | tr '\n' ' ') = *${CONTEXT}* ]]; then
+if echo $(kind get clusters | tr '\n' ' ') | grep -q "\b${CONTEXT}\b"; then
   echo "Cluster ${CONTEXT} already started"
   kubectl config use-context kind-${CONTEXT}
   return

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -31,7 +31,8 @@ if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
 fi
 
 # Abort if the cluster exists; if so, ensure the kubeconfig is exported
-if echo $(kind get clusters | tr '\n' ' ') | grep -q "\b${CONTEXT}\b"; then
+CLUSTERS=($(kind get clusters | tr '\n' ' '))
+if [[ ${CLUSTERS[@]} =~ "\<${CONTEXT}\>" ]]; then
   echo "Cluster ${CONTEXT} already started"
   kubectl config use-context kind-${CONTEXT}
   return

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -8,6 +8,7 @@ for cmd in "docker" "kind" "cilium" "kubectl" "jq"; do
 done
 
 CONTEXT=${CONTEXT-kind} # Kubeconfig Profile and cluster sub-domain
+DOMAIN=${DOMAIN-${CONTEXT}.cluster.local}
 WORKERS=${WORKERS-2} # Number of worker nodes in the clusters
 SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for Cilium L2/LB
 CLUSTER_ID=${CLUSTER_ID-1}
@@ -15,7 +16,19 @@ POD_CIDR=${POD_CIDR-10.244.0.0/16}
 SVC_CIDR=${SVC_CIDR-10.96.0.0/12}
 MASTER=${CONTEXT}-control-plane
 CILIUM_VERSION=${CILIUM_VERSION-1.15.3}
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 HOST_IP=${HOST_IP-127.0.0.1} # The IP address of your machine to expose API Server (don't change when using OrbStack)
+
+HUBBLE_ENABLED="false"
+ENCRYPTION_ENABLED="false"
+if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
+  ENCRYPTION_ENABLED="true" # Assumes Linkerd is not present.
+  HUBBLE_ENABLED="true" # Assumes Linkerd-Viz unavailable.
+  if [ ! -f "cilium-ca.crt" ]; then
+    echo "cilium-ca.crt not found; please run deploy-certs.sh"
+    exit 1
+  fi
+fi
 
 # Abort if the cluster exists; if so, ensure the kubeconfig is exported
 if [[ $(kind get clusters | tr '\n' ' ') = *${CONTEXT}* ]]; then
@@ -59,6 +72,13 @@ networking:
   serviceSubnet: ${SVC_CIDR}
 EOF
 
+if [ -e cilium-ca.crt ] && [ -e cilium-ca.key ]; then
+  kubectl create secret generic cilium-ca -n kube-system --from-file=ca.crt=cilium-ca.crt --from-file=ca.key=cilium-ca.key
+  kubectl label secret -n kube-system cilium-ca app.kubernetes.io/managed-by=Helm
+  kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-name=cilium
+  kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-namespace=kube-system
+fi
+
 cilium install --version ${CILIUM_VERSION} --wait \
   --set cluster.id=${CLUSTER_ID} \
   --set cluster.name=${CONTEXT} \
@@ -69,7 +89,12 @@ cilium install --version ${CILIUM_VERSION} --wait \
   --set socketLB.enabled=true \
   --set socketLB.hostNamespaceOnly=true \
   --set k8sClientRateLimit.qps=50 \
-  --set k8sClientRateLimit.burst=100
+  --set k8sClientRateLimit.burst=100 \
+  --set encryption.enabled=${ENCRYPTION_ENABLED} \
+  --set encryption.type=wireguard \
+  --set hubble.relay.enabled=${HUBBLE_ENABLED} \
+  --set hubble.ui.enabled=${HUBBLE_ENABLED} \
+  --set hubble.peerService.clusterDomain=${DOMAIN}
 
 cilium status --wait --ignore-warnings
 
@@ -100,3 +125,8 @@ spec:
   externalIPs: true
   loadBalancerIPs: true
 EOF
+
+if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
+  cilium clustermesh enable --service-type LoadBalancer
+  cilium clustermesh status --wait
+fi

--- a/deploy-link.sh
+++ b/deploy-link.sh
@@ -7,6 +7,18 @@ for cmd in "kubectl" "cilium" "linkerd"; do
   type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
 done
 
+echo "Setting up namespaces"
+for ns in observability mimir tempo loki $APP_NS; do
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $ns
+  annotations:
+    linkerd.io/inject: enabled
+EOF
+done
+
 CENTRAL=${CENTRAL-lgtm-central}
 CONTEXT=${CONTEXT-lgtm-remote}
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}

--- a/deploy-link.sh
+++ b/deploy-link.sh
@@ -17,6 +17,16 @@ REMOTE_CTX=kind-${CONTEXT}
 echo "Creating link from ${REMOTE_CTX} to ${CENTRAL_CTX}"
 if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
   cilium clustermesh connect --context ${REMOTE_CTX} --destination-context ${CENTRAL_CTX}
+
+  # Create copies of the global services
+  kubectl --context ${CENTRAL_CTX} get service/mimir-distributor -n mimir -o yaml | \
+    sed '/clusterIP:/,+2d' | kubectl --context ${REMOTE_CTX} apply -f -
+  kubectl --context ${CENTRAL_CTX} get service/tempo-distributor -n tempo -o yaml | \
+    sed '/clusterIP:/,+2d' | kubectl --context ${REMOTE_CTX} apply -f -
+  kubectl --context ${CENTRAL_CTX} get service/loki-write -n loki -o yaml | \
+    sed '/clusterIP:/,+2d' | kubectl --context ${REMOTE_CTX} apply -f -
+  kubectl --context ${CENTRAL_CTX} get service/monitor-alertmanager -n observability -o yaml | \
+    sed '/clusterIP:/,+2d' | kubectl --context ${REMOTE_CTX} apply -f -
 else
   # The following is required when using Kind/Docker without apiServerAddress on Kind config.
   API_SERVER=$(kubectl get node --context ${CENTRAL_CTX} -l node-role.kubernetes.io/control-plane -o json \

--- a/deploy-link.sh
+++ b/deploy-link.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+for cmd in "kubectl" "cilium" "linkerd"; do
+  type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
+done
+
+CENTRAL=${CENTRAL-lgtm-central}
+CONTEXT=${CONTEXT-lgtm-remote}
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
+
+CENTRAL_CTX=kind-${CENTRAL}
+REMOTE_CTX=kind-${CONTEXT}
+
+echo "Creating link from ${REMOTE_CTX} to ${CENTRAL_CTX}"
+if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
+  cilium clustermesh connect --context ${REMOTE_CTX} --destination-context ${CENTRAL_CTX}
+else
+  # The following is required when using Kind/Docker without apiServerAddress on Kind config.
+  API_SERVER=$(kubectl get node --context ${CENTRAL_CTX} -l node-role.kubernetes.io/control-plane -o json \
+    | jq -r '.items[] | .status.addresses[] | select(.type=="InternalIP") | .address')
+
+  linkerd mc link --context ${CENTRAL_CTX} --cluster-name ${CENTRAL} \
+    --api-server-address="https://${API_SERVER}:6443" \
+    | kubectl apply --context ${REMOTE_CTX} -f -
+fi

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -14,8 +14,9 @@ DOMAIN=${DOMAIN-${CONTEXT}.cluster.local}
 SUBNET=${SUBNET-240} # For Cilium L2/LB
 WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-3}
-POD_CIDR=${POD_CIDR-10.5.0.0/16}
-SVC_CIDR=${SVC_CIDR-10.6.0.0/16}
+POD_CIDR=${POD_CIDR-10.31.0.0/16}
+SVC_CIDR=${SVC_CIDR-10.32.0.0/16}
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 
 LINKERD_JAEGER_ENABLED=no # Linkerd Jaeger doesn't support OTLP
 
@@ -25,20 +26,13 @@ echo "Deploying Kubernetes"
 echo "Deploying Prometheus CRDs"
 helm upgrade --install prometheus-crds prometheus-community/prometheus-operator-crds
 
-echo "Deploying Linkerd"
-. deploy-linkerd.sh
+if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" != "yes" ]]; then
+  echo "Deploying Linkerd"
+  . deploy-linkerd.sh
+fi
 
-CENTRAL_CTX=kind-${CENTRAL}
-REMOTE_CTX=kind-${CONTEXT}
-
-# The following is required when using Kind/Docker without apiServerAddress on Kind config.
-API_SERVER=$(kubectl get node --context ${CENTRAL_CTX} -l node-role.kubernetes.io/control-plane -o json \
-  | jq -r '.items[] | .status.addresses[] | select(.type=="InternalIP") | .address')
-
-echo "Creating link from ${REMOTE_CTX} to ${CENTRAL_CTX}"
-linkerd mc link --context ${CENTRAL_CTX} --cluster-name ${CENTRAL} \
-  --api-server-address="https://${API_SERVER}:6443" \
-  | kubectl apply --context ${REMOTE_CTX} -f -
+echo "Connect to Central"
+. deploy-link.sh
 
 echo "Setting up namespaces"
 for ns in observability mimir tempo loki otel; do

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -11,13 +11,12 @@ CENTRAL=${CENTRAL-lgtm-central}
 CERT_ISSUER_ID=${CERT_ISSUER_ID-issuer-otel}
 CONTEXT=${CONTEXT-lgtm-remote-otel}
 DOMAIN=${DOMAIN-${CONTEXT}.cluster.local}
-SUBNET=${SUBNET-240} # For Cilium L2/LB
+SUBNET=${SUBNET-232} # For Cilium L2/LB (must be unique across all clusters)
 WORKERS=${WORKERS-1}
-CLUSTER_ID=${CLUSTER_ID-3}
-POD_CIDR=${POD_CIDR-10.31.0.0/16}
-SVC_CIDR=${SVC_CIDR-10.32.0.0/16}
+CLUSTER_ID=${CLUSTER_ID-3} # Unique on each cluster
+POD_CIDR=${POD_CIDR-10.31.0.0/16} # Unique on each cluster
+SVC_CIDR=${SVC_CIDR-10.32.0.0/16} # Unique on each cluster
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
-LINKERD_JAEGER_ENABLED=no # Linkerd Jaeger doesn't support OTLP
 APP_NS="otel"
 
 echo "Deploying Kubernetes"

--- a/deploy-remote.sh
+++ b/deploy-remote.sh
@@ -11,11 +11,11 @@ CENTRAL=${CENTRAL-lgtm-central}
 CERT_ISSUER_ID=${CERT_ISSUER_ID-issuer-remote}
 CONTEXT=${CONTEXT-lgtm-remote}
 DOMAIN=${DOMAIN-${CONTEXT}.cluster.local}
-SUBNET=${SUBNET-240} # For Cilium L2/LB
+SUBNET=${SUBNET-240} # For Cilium L2/LB (must be unique across all clusters)
 WORKERS=${WORKERS-1}
-CLUSTER_ID=${CLUSTER_ID-2}
-POD_CIDR=${POD_CIDR-10.21.0.0/16}
-SVC_CIDR=${SVC_CIDR-10.22.0.0/16}
+CLUSTER_ID=${CLUSTER_ID-2} # Unique on each cluster
+POD_CIDR=${POD_CIDR-10.21.0.0/16} # Unique on each cluster
+SVC_CIDR=${SVC_CIDR-10.22.0.0/16} # Unique on each cluster
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 APP_NS="tns"
 

--- a/deploy-remote.sh
+++ b/deploy-remote.sh
@@ -17,6 +17,7 @@ CLUSTER_ID=${CLUSTER_ID-2}
 POD_CIDR=${POD_CIDR-10.21.0.0/16}
 SVC_CIDR=${SVC_CIDR-10.22.0.0/16}
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
+APP_NS="tns"
 
 echo "Deploying Kubernetes"
 . deploy-kind.sh
@@ -31,18 +32,6 @@ fi
 
 echo "Connect to Central"
 . deploy-link.sh
-
-echo "Setting up namespaces"
-for ns in observability mimir tempo loki tns; do
-  cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: $ns
-  annotations:
-    linkerd.io/inject: enabled
-EOF
-done
 
 echo "Deploying Prometheus (for Metrics)"
 helm upgrade --install monitor prometheus-community/kube-prometheus-stack \
@@ -59,4 +48,4 @@ helm upgrade --install grafana-agent grafana/grafana-agent \
   -n observability -f values-agent.yaml --wait
 
 echo "Deploying Grafana TNS application"
-kubectl apply -f grafana-tns-apps.yaml
+kubectl apply -n ${APP_NS} -f grafana-tns-apps.yaml


### PR DESCRIPTION
Linkerd works excellently to protect data in transit between pods running in the same cluster and between different clusters.

However, there are other approaches to connecting multiple clusters securely and encrypting the communication between worker nodes. With that in mind, this PR allows the user to use Cilium ClusterMesh to replace Linkerd, which should reduce resource consumption on the system. Indeed, we won't have mTLS between Pods, but data will be protected when it goes outside the worker nodes.