### PR TITLE
Add memory constraints to Tempo cache.

### DIFF
--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -72,6 +72,13 @@ metricsGenerator:
 
 memcached:
   replicas: 2
+  extraArgs:
+  - -m 256 # To avoid the default of 64 (megabytes)
+  resources: # Memory must be greater than `-m`
+    requests:
+      memory: 284Mi
+    limits:
+      memory: 284Mi
 
 storage:
   trace:


### PR DESCRIPTION
Memcached in Tempo uses its default, which barely works for testing purposes. Therefore, I added some changes to help users understand what needs to be done to set memory limits for Memcached (and the Pods that run it) based on how that works in the latest Mimir and Loki 3.x.