### PR TITLE
Deploy metrics server (and other minor improvements).

### DIFF
--- a/deploy-central.sh
+++ b/deploy-central.sh
@@ -22,6 +22,7 @@ echo "Updating Helm Repositories"
 helm repo add jetstack https://charts.jetstack.io
 helm repo add linkerd https://helm.linkerd.io/stable
 helm repo add linkerd-edge https://helm.linkerd.io/edge
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo add grafana https://grafana.github.io/helm-charts


### PR DESCRIPTION
I decided to deploy the metrics server to improve cluster monitoring through `kubectl`.

Other enhancements:
* Use `DOMAIN` for `dnsDomain` to avoid repetitions.
* Calculate the appropriate CIDR based on the Kind network.