### PR TITLE
Grafana Alloy improvements (plus extras).

### DIFF
--- a/deploy-central.sh
+++ b/deploy-central.sh
@@ -78,7 +78,7 @@ echo "Deploying Grafana Promtail (for Logs)"
 helm upgrade --install promtail grafana/promtail \
   -n observability -f values-promtail-common.yaml -f values-promtail-central.yaml --wait
 
-echo "Deplyoing Grafana Alloy (for Traces)"
+echo "Deploying Grafana Alloy (for Traces)"
 helm upgrade --install alloy -n observability grafana/alloy \
   -f values-alloy.yaml \
   --set-file alloy.configMap.content=grafana-central-config.alloy \

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -14,7 +14,7 @@ SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for Cilium L2/
 CLUSTER_ID=${CLUSTER_ID-1}
 POD_CIDR=${POD_CIDR-10.244.0.0/16}
 SVC_CIDR=${SVC_CIDR-10.96.0.0/12}
-CILIUM_VERSION=${CILIUM_VERSION-1.15.3}
+CILIUM_VERSION=${CILIUM_VERSION-1.15.4}
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 HOST_IP=${HOST_IP-127.0.0.1} # The IP address of your machine to expose API Server (don't change when using OrbStack)
 

--- a/deploy-linkerd.sh
+++ b/deploy-linkerd.sh
@@ -11,7 +11,7 @@ CERT_ISSUER_ID=${CERT_ISSUER_ID-}
 DOMAIN=${DOMAIN-}
 LINKERD_HA=${LINKERD_HA-no}
 LINKERD_VIZ_ENABLED=${LINKERD_VIZ_ENABLED-yes}
-LINKERD_JAEGER_ENABLED=${LINKERD_JAEGER_ENABLED-yes}
+LINKERD_JAEGER_ENABLED=${LINKERD_JAEGER_ENABLED-no}
 LINKERD_REPO=${LINKERD_REPO-stable} # Either stable (2.14) or edge
 
 REPOSITORY_NAME="linkerd"
@@ -88,16 +88,16 @@ if [[ "$LINKERD_VIZ_ENABLED" == "yes" ]]; then
   --wait
 fi
 
-# Requires Grafana Agent
+# Requires Grafana Alloy or Tempo
 if [[ "$LINKERD_JAEGER_ENABLED" == "yes" ]]; then
-  echo "Deploying Linkerd-Jaeger via Grafana Agent"
+  echo "Deploying Linkerd-Jaeger via Grafana Alloy"
   helm upgrade --install linkerd-jaeger $REPOSITORY_NAME/linkerd-jaeger \
   --namespace linkerd-jaeger --create-namespace \
   --set clusterDomain=$DOMAIN \
   --set collector.enabled=false \
   --set jaeger.enabled=false \
-  --set webhook.collectorSvcAddr=grafana-agent.observability.svc:55678 \
-  --set webhook.collectorSvcAccount=grafana-agent \
+  --set webhook.collectorSvcAddr=grafana-alloy.observability.svc:55678 \
+  --set webhook.collectorSvcAccount=grafana-alloy \
   --wait
 fi
 

--- a/deploy-remote.sh
+++ b/deploy-remote.sh
@@ -48,7 +48,7 @@ echo "Deploying Grafana Promtail (for Logs)"
 helm upgrade --install promtail grafana/promtail \
   -n observability -f values-promtail-common.yaml -f /tmp/values-promtail-remote.yaml --wait
 
-echo "Deplyoing Grafana Alloy (for Traces)"
+echo "Deploying Grafana Alloy (for Traces)"
 helm upgrade --install alloy -n observability grafana/alloy \
   -f values-alloy.yaml \
   --set-file alloy.configMap.content=/tmp/grafana-remote-config.alloy \

--- a/grafana-central-config.alloy
+++ b/grafana-central-config.alloy
@@ -1,4 +1,4 @@
-// For Linkerd (port 55678)
+// For Linkerd Jaeger when enabled (port 55678)
 otelcol.receiver.opencensus "default" {
 	output {
 		metrics = []

--- a/grafana-remote-config.alloy
+++ b/grafana-remote-config.alloy
@@ -1,43 +1,19 @@
-otelcol.receiver.otlp "default" {
-	grpc {
-		include_metadata = true
-	}
-
-	http {
-		include_metadata = true
-	}
-
-	output {
-		metrics = []
-		logs    = []
-		traces  = [otelcol.processor.batch.default.input]
-	}
-}
-
-otelcol.receiver.jaeger "default" {
-	protocols {
-		grpc { }
-
-		thrift_http { }
-
-		thrift_binary {
-			max_packet_size = "63KiB488B"
-		}
-
-		thrift_compact {
-			max_packet_size = "63KiB488B"
-		}
-	}
-
-	output {
-		traces = [otelcol.processor.batch.default.input]
-	}
-}
-
+// For Linkerd Jaeger when enabled (port 55678)
 otelcol.receiver.opencensus "default" {
 	output {
 		metrics = []
 		traces  = [otelcol.processor.batch.default.input]
+	}
+}
+
+// TNS Application (port 6831)
+otelcol.receiver.jaeger "default" {
+	protocols {
+		thrift_compact { }
+	}
+
+	output {
+		traces = [otelcol.processor.batch.default.input]
 	}
 }
 

--- a/grafana-tns-apps.yaml
+++ b/grafana-tns-apps.yaml
@@ -90,7 +90,7 @@ spec:
         - http://db
         env:
         - name: JAEGER_AGENT_HOST
-          value: grafana-agent.observability.svc
+          value: grafana-alloy.observability.svc
         - name: JAEGER_TAGS
           value: cluster=lgtm-remote,namespace=tns
         - name: JAEGER_SAMPLER_TYPE
@@ -126,7 +126,7 @@ spec:
         - -log.level=debug
         env:
         - name: JAEGER_AGENT_HOST
-          value: grafana-agent.observability.svc
+          value: grafana-alloy.observability.svc
         - name: JAEGER_TAGS
           value: cluster=lgtm-remote,namespace=tns
         - name: JAEGER_SAMPLER_TYPE
@@ -163,7 +163,7 @@ spec:
         - http://app
         env:
         - name: JAEGER_AGENT_HOST
-          value: grafana-agent.observability.svc
+          value: grafana-alloy.observability.svc
         - name: JAEGER_TAGS
           value: cluster=lgtm-remote,namespace=tns
         - name: JAEGER_SAMPLER_TYPE

--- a/values-alloy.yaml
+++ b/values-alloy.yaml
@@ -1,6 +1,6 @@
 # Warning: there won't be any resource requests/limits for any grafana alloy-related container
 ---
-fullnameOverride: grafana-agent # To simplify compatibility
+fullnameOverride: grafana-alloy
 
 rbac:
   create: false

--- a/values-ingress.yaml
+++ b/values-ingress.yaml
@@ -27,7 +27,7 @@ controller:
     enable-opentelemetry: "true"
     opentelemetry-trust-incoming-span: "false"
     opentelemetry-operation-name: HTTP $request_method $service_name $location_path
-    otlp-collector-host: grafana-agent.observability.svc
+    otlp-collector-host: grafana-alloy.observability.svc
     otel-service-name: nginx-internal
     otel-sampler: AlwaysOn
     otel-sampler-ratio: "1.0"

--- a/values-mimir.yaml
+++ b/values-mimir.yaml
@@ -7,7 +7,7 @@ serviceAccount: # There is no way to set an account per component
 global:
   extraEnv:
   - name: JAEGER_ENDPOINT
-    value: 'http://grafana-agent.observability.svc:14268/api/traces'
+    value: 'http://grafana-alloy.observability.svc:14268/api/traces'
   - name: JAEGER_SAMPLER_TYPE
     value: 'const'
   - name: JAEGER_SAMPLER_PARAM


### PR DESCRIPTION
* Simplified Grafana Allow configuration and removed any reference to Grafana Agent.
* Disable Linkerd Jaeger by default (honestly, not needed here due to the B3 propagation for applications that still use the Jaeger Client).
* Updated Cilium to 1.15.4.
