### PR TITLE
Add support for Istio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Due to a [change](https://buoyant.io/blog/clarifications-on-linkerd-2-15-stable-
 
 ### Istio Multi Cluster
 
-> **WARNING:** Istio support is a work in progress. In theory, setting `appProtocol: tcp` for all GRPC services (especially `memberlist`) and ensuring the presence of headless services (i.e., `clusterIP: None`) to guarantee that the proxy will have endpoints per Pod IP address should allow all Grafana applications to work correctly. However, the integration with Prometheus and traces via Grafana Allow has not yet been enabled (as it exists for Linkerd).
+> **WARNING:** Istio support is a work in progress. In theory, setting `appProtocol: tcp` for all GRPC services (especially `memberlist`) and ensuring the presence of headless services (i.e., `clusterIP: None`) guarantees that the proxy will have endpoints per Pod IP address should allow all Grafana applications to work correctly. Modern Helm charts for Loki, Tempo, and Mimir allow configuration `appProtocol`; there are already headless services for all the microservices. The configuration flexibility varies, but everything seems to be working.
 
 The PoC assumes Istio [multi-cluster](https://istio.io/latest/docs/setup/install/multicluster/primary-remote_multi-network/) using multi-network, which requires an Istio Gateway. In other words, the environment assumes we're interconnecting two clusters from different networks using Istio.
+
+Please note that the integration with Prometheus and traces via Grafana Allow has not yet been enabled (as it exists for Linkerd).
 
 ### Cilium Cluster
 
@@ -334,6 +336,14 @@ Then, access the Grafana WebUI available at `https://grafana.example.com` and ac
 The password for the `admin` account is defined in [values-prometheus-central.yaml](./values-prometheus-central.yaml) (i.e., `Adm1nAdm1n`). From the Explore tab, you should be able to access the data collected locally and received from the remote location using the data sources described initially.
 
 Within the [dashboards](./dashboards/) subdirectory, you should find a sample dashboard for the TNS App that you can use to visualize metrics from more locations based on the metrics stored in the central location. If you check the logs for that application (`tns` namespace), you can visualize the remote logs stored on the central Loki and the traces.
+
+### Troubleshooting
+
+For some reason, sometimes the Ingress controller doesn't correctly apply the Ingress resource, and after updating `/etc/hosts`, the Grafana UI is still unreachable. If that happens, the easiest solution is to restart the Ingress controller:
+
+```bash
+kubectl rollout restart deployment -n ingress-nginx ingress-nginx-controller --context kind-lgtm-central
+```
 
 ## Shutdown
 

--- a/deploy-istio.sh
+++ b/deploy-istio.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+for cmd in "istioctl" "kubectl"; do
+  type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
+done
+
+CONTEXT=${CONTEXT-}
+CERT_ISSUER_ID=${CERT_ISSUER_ID-}
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  labels:
+    topology.istio.io/network: ${CONTEXT}
+EOF
+
+# https://istio.io/latest/docs/tasks/security/cert-management/plugin-ca-cert/
+kubectl create secret generic cacerts -n istio-system \
+  --from-file=root-cert.pem=istio-root-ca.crt \
+  --from-file=ca-cert.pem=istio-${CERT_ISSUER_ID}.crt \
+  --from-file=ca-key.pem=istio-${CERT_ISSUER_ID}.key \
+  --from-file=cert-chain.pem=istio-${CERT_ISSUER_ID}-chain.crt
+
+# TODO clusterDomain, trustDomain
+
+# https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
+# https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/
+# https://istio.io/v1.5/docs/reference/config/installation-options/
+cat <<EOF | istioctl install -y -f -
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      meshID: mesh1
+      multiCluster:
+        clusterName: ${CONTEXT}
+      network: ${CONTEXT}
+  components:
+    ingressGateways:
+    - name: lgtm-gateway
+      label:
+        istio: lgtm-gateway
+        app: lgtm-gateway
+        topology.istio.io/network: ${CONTEXT}
+      enabled: true
+      k8s:
+        env:
+        # traffic through this gateway should be routed inside the network
+        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+          value: ${CONTEXT}
+        service:
+          ports:
+          - name: status-port
+            port: 15021
+            targetPort: 15021
+          - name: tls
+            port: 15443
+            targetPort: 15443
+          - name: tls-istiod
+            port: 15012
+            targetPort: 15012
+          - name: tls-webhook
+            port: 15017
+            targetPort: 15017
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: cross-network-gateway
+  namespace: istio-system
+spec:
+  selector:
+    # Must match label from Ingress Gateway
+    istio: lgtm-gateway
+  servers:
+  - port:
+      number: 15443
+      name: tls
+      protocol: TLS
+    tls:
+      mode: AUTO_PASSTHROUGH
+    hosts:
+    - "*.local"
+EOF

--- a/deploy-istio.sh
+++ b/deploy-istio.sh
@@ -26,11 +26,8 @@ kubectl create secret generic cacerts -n istio-system \
   --from-file=ca-key.pem=istio-${CERT_ISSUER_ID}.key \
   --from-file=cert-chain.pem=istio-${CERT_ISSUER_ID}-chain.crt
 
-# TODO clusterDomain, trustDomain
-
 # https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
 # https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/
-# https://istio.io/v1.5/docs/reference/config/installation-options/
 cat <<EOF | istioctl install -y -f -
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -41,6 +38,29 @@ spec:
       multiCluster:
         clusterName: ${CONTEXT}
       network: ${CONTEXT}
+      proxy:
+        holdApplicationUntilProxyStarts: true
+        resources:
+          limits:
+            cpu: '0'
+            memory: '0'
+          requests:
+            cpu: '0'
+            memory: '0'
+      proxy_init:
+        resources:
+          limits:
+            cpu: '0'
+            memory: '0'
+          requests:
+            cpu: '0'
+            memory: '0'
+  meshConfig:
+    defaultConfig:
+      holdApplicationUntilProxyStarts: true
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "true"
+        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
   components:
     ingressGateways:
     - name: lgtm-gateway
@@ -54,6 +74,13 @@ spec:
         # traffic through this gateway should be routed inside the network
         - name: ISTIO_META_REQUESTED_NETWORK_VIEW
           value: ${CONTEXT}
+        resources:
+          limits:
+            cpu: '0'
+            memory: '0'
+          requests:
+            cpu: '0'
+            memory: '0'
         service:
           ports:
           - name: status-port

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -7,8 +7,7 @@ for cmd in "docker" "kind" "cilium" "kubectl" "jq" "helm"; do
   type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
 done
 
-CONTEXT=${CONTEXT-kind} # Kubeconfig profile and cluster domain
-DOMAIN=${DOMAIN-${CONTEXT}.cluster.local}
+CONTEXT=${CONTEXT-kind} # Kubeconfig profile
 WORKERS=${WORKERS-2} # Number of worker nodes in the clusters
 SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for Cilium L2/LB
 CLUSTER_ID=${CLUSTER_ID-1}
@@ -55,13 +54,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: ${CONTEXT}
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
-  - |
-    ---
-    apiVersion: kubeadm.k8s.io/v1beta3
-    kind: ClusterConfiguration
-    networking:
-      dnsDomain: ${DOMAIN}
 ${WORKER_YAML}
 networking:
   ipFamily: ipv4
@@ -96,8 +88,7 @@ cilium install --version ${CILIUM_VERSION} --wait \
   --set encryption.enabled=${ENCRYPTION_ENABLED} \
   --set encryption.type=wireguard \
   --set hubble.relay.enabled=${HUBBLE_ENABLED} \
-  --set hubble.ui.enabled=${HUBBLE_ENABLED} \
-  --set hubble.peerService.clusterDomain=${DOMAIN}
+  --set hubble.ui.enabled=${HUBBLE_ENABLED}
 
 cilium status --wait --ignore-warnings
 

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -14,7 +14,7 @@ SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for Cilium L2/
 CLUSTER_ID=${CLUSTER_ID-1}
 POD_CIDR=${POD_CIDR-10.244.0.0/16}
 SVC_CIDR=${SVC_CIDR-10.96.0.0/12}
-CILIUM_VERSION=${CILIUM_VERSION-1.16.0}
+CILIUM_VERSION=${CILIUM_VERSION-1.16.2}
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 HOST_IP=${HOST_IP-127.0.0.1} # The IP address of your machine to expose API Server (don't change when using Docker-based solutions)
 
@@ -84,6 +84,7 @@ cilium install --version ${CILIUM_VERSION} --wait \
   --set cluster.id=${CLUSTER_ID} \
   --set cluster.name=${CONTEXT} \
   --set ipam.mode=kubernetes \
+  --set cni.exclusive=false \
   --set envoy.enabled=false \
   --set devices=eth+ \
   --set l2announcements.enabled=true \

--- a/deploy-linkerd.sh
+++ b/deploy-linkerd.sh
@@ -8,7 +8,6 @@ for cmd in "helm" "kubectl"; do
 done
 
 CERT_ISSUER_ID=${CERT_ISSUER_ID-}
-DOMAIN=${DOMAIN-}
 LINKERD_HA=${LINKERD_HA-no}
 LINKERD_VIZ_ENABLED=${LINKERD_VIZ_ENABLED-yes}
 LINKERD_JAEGER_ENABLED=${LINKERD_JAEGER_ENABLED-no}
@@ -21,11 +20,6 @@ fi
 
 if [[ "$CERT_ISSUER_ID" == "" ]]; then
   echo "CERT_ISSUER_ID env-var required"
-  exit 1
-fi
-
-if [[ "$DOMAIN" == "" ]]; then
-  echo "DOMAIN env-var required"
   exit 1
 fi
 
@@ -60,8 +54,6 @@ if [[ "$LINKERD_HA" == "yes" ]]; then
 fi
 helm upgrade --install linkerd-control-plane $REPOSITORY_NAME/linkerd-control-plane \
   --namespace linkerd \
-  --set clusterDomain=$DOMAIN \
-  --set identityTrustDomain=$DOMAIN \
   --set-file identityTrustAnchorsPEM=linkerd-ca.crt \
   --set-file identity.issuer.tls.crtPEM=linkerd-$CERT_ISSUER_ID.crt \
   --set-file identity.issuer.tls.keyPEM=linkerd-$CERT_ISSUER_ID.key \
@@ -79,8 +71,6 @@ if [[ "$LINKERD_VIZ_ENABLED" == "yes" ]]; then
   echo "Deploying Linkerd-Viz"
   helm upgrade --install linkerd-viz $REPOSITORY_NAME/linkerd-viz \
   --namespace linkerd-viz --create-namespace \
-  --set clusterDomain=$DOMAIN \
-  --set identityTrustDomain=$DOMAIN \
   --set grafana.enabled=false \
   --set prometheus.enabled=false \
   --set prometheusUrl=http://monitor-prometheus.observability.svc:9090 \
@@ -93,7 +83,6 @@ if [[ "$LINKERD_JAEGER_ENABLED" == "yes" ]]; then
   echo "Deploying Linkerd-Jaeger via Grafana Alloy"
   helm upgrade --install linkerd-jaeger $REPOSITORY_NAME/linkerd-jaeger \
   --namespace linkerd-jaeger --create-namespace \
-  --set clusterDomain=$DOMAIN \
   --set collector.enabled=false \
   --set jaeger.enabled=false \
   --set webhook.collectorSvcAddr=grafana-alloy.observability.svc:55678 \
@@ -104,5 +93,4 @@ fi
 echo "Deploying Linkerd Multicluster"
 helm upgrade --install linkerd-multicluster $REPOSITORY_NAME/linkerd-multicluster \
   --namespace linkerd-multicluster --create-namespace \
-  --set identityTrustDomain=$DOMAIN \
   --wait

--- a/deploy-linkerd.sh
+++ b/deploy-linkerd.sh
@@ -36,13 +36,13 @@ if [ ! -f $CERT_EXPIRY_FILE ]; then
 fi
 CERT_EXPIRY_DATE=$(cat $CERT_EXPIRY_FILE)
 
-if [ ! -f ca.crt ]; then
-  echo "ca.crt not found; please run deploy-certs.sh"
+if [ ! -f "linkerd-ca.crt" ]; then
+  echo "linkerd-ca.crt not found; please run deploy-certs.sh"
   exit 1
 fi
 
-if [ ! -f "$CERT_ISSUER_ID.crt" ]; then
-  echo "$CERT_ISSUER_ID.crt not found; please run deploy-certs.sh"
+if [ ! -f "linkerd-$CERT_ISSUER_ID.crt" ]; then
+  echo "linkerd-$CERT_ISSUER_ID.crt not found; please run deploy-certs.sh"
   exit 1
 fi
 
@@ -62,9 +62,9 @@ helm upgrade --install linkerd-control-plane $REPOSITORY_NAME/linkerd-control-pl
   --namespace linkerd \
   --set clusterDomain=$DOMAIN \
   --set identityTrustDomain=$DOMAIN \
-  --set-file identityTrustAnchorsPEM=ca.crt \
-  --set-file identity.issuer.tls.crtPEM=$CERT_ISSUER_ID.crt \
-  --set-file identity.issuer.tls.keyPEM=$CERT_ISSUER_ID.key \
+  --set-file identityTrustAnchorsPEM=linkerd-ca.crt \
+  --set-file identity.issuer.tls.crtPEM=linkerd-$CERT_ISSUER_ID.crt \
+  --set-file identity.issuer.tls.keyPEM=linkerd-$CERT_ISSUER_ID.key \
   --set identity.issuer.crtExpiry=$CERT_EXPIRY_DATE \
   ${helm_values_args[@]} \
   --wait

--- a/deploy-mesh.sh
+++ b/deploy-mesh.sh
@@ -3,9 +3,39 @@
 set -euo pipefail
 trap 's=$?; echo >&2 "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-for cmd in "kubectl" "cilium" "linkerd"; do
-  type $cmd >/dev/null 2>&1 || { echo >&2 "$cmd required but it's not installed; aborting."; exit 1; }
-done
+CENTRAL=${CENTRAL-lgtm-central}
+CONTEXT=${CONTEXT-lgtm-remote}
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no} # no for Linkerd or Istio, yes for Cilium CM
+ISTIO_ENABLED=${ISTIO_ENABLED-no} # no for Linkerd, yes for Istio
+
+CENTRAL_CTX=kind-${CENTRAL}
+REMOTE_CTX=kind-${CONTEXT}
+
+# Configuration files designed for Linkerd MC that requires alterations to work with Istio or Cilium CM
+FILES=${FILES:-}
+
+# Application Namespace
+APP_NS=${APP_NS:-}
+
+patch_files() {
+  for FILE in "${FILES[@]}"; do
+    sed "s/-${CENTRAL}//" "${FILE}" > "/tmp/${FILE}"
+  done
+}
+
+cp "${FILES[@]}" /tmp
+if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
+  patch_files
+else
+  if [[ "${ISTIO_ENABLED}" == "yes" ]]; then
+    patch_files
+    echo "Deploying Istio"
+    . deploy-istio.sh
+  else
+    echo "Deploying Linkerd"
+    . deploy-linkerd.sh
+  fi
+fi
 
 echo "Setting up namespaces"
 for ns in observability mimir tempo loki $APP_NS; do
@@ -20,14 +50,6 @@ metadata:
     linkerd.io/inject: enabled
 EOF
 done
-
-CENTRAL=${CENTRAL-lgtm-central}
-CONTEXT=${CONTEXT-lgtm-remote}
-CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no} # no for Linkerd or Istio, yes for Cilium CM
-ISTIO_ENABLED=${ISTIO_ENABLED-no} # no for Linkerd, yes for Istio
-
-CENTRAL_CTX=kind-${CENTRAL}
-REMOTE_CTX=kind-${CONTEXT}
 
 echo "Creating link from ${REMOTE_CTX} to ${CENTRAL_CTX}"
 if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -16,7 +16,8 @@ WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-3} # Unique on each cluster
 POD_CIDR=${POD_CIDR-10.31.0.0/16} # Unique on each cluster
 SVC_CIDR=${SVC_CIDR-10.32.0.0/16} # Unique on each cluster
-CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no} # no for Linkerd or Istio, yes for Cilium CM
+ISTIO_ENABLED=${ISTIO_ENABLED-no} # no for Linkerd, yes for Istio
 APP_NS="otel" # Used by deploy-link.sh
 
 echo "Deploying Kubernetes"
@@ -32,8 +33,13 @@ if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
     sed "s/-${CENTRAL}//" "${FILE}" > "/tmp/${FILE}"
   done
 else
-  echo "Deploying Linkerd"
-  . deploy-linkerd.sh
+  if [[ "${ISTIO_ENABLED}" == "yes" ]]; then
+    echo "Deploying Istio"
+    . deploy-istio.sh
+  else
+    echo "Deploying Linkerd"
+    . deploy-linkerd.sh
+  fi
 fi
 
 echo "Connect to Central"

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -10,7 +10,6 @@ done
 CENTRAL=${CENTRAL-lgtm-central}
 CERT_ISSUER_ID=${CERT_ISSUER_ID-issuer-otel}
 CONTEXT=${CONTEXT-lgtm-remote-otel}
-DOMAIN=${DOMAIN-${CONTEXT}.cluster.local}
 SUBNET=${SUBNET-232} # For Cilium L2/LB (must be unique across all clusters)
 WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-3} # Unique on each cluster
@@ -18,7 +17,7 @@ POD_CIDR=${POD_CIDR-10.31.0.0/16} # Unique on each cluster
 SVC_CIDR=${SVC_CIDR-10.32.0.0/16} # Unique on each cluster
 CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no} # no for Linkerd or Istio, yes for Cilium CM
 ISTIO_ENABLED=${ISTIO_ENABLED-no} # no for Linkerd, yes for Istio
-APP_NS="otel" # Used by deploy-link.sh
+APP_NS="otel" # Used by deploy-mesh.sh
 
 echo "Deploying Kubernetes"
 . deploy-kind.sh
@@ -26,29 +25,13 @@ echo "Deploying Kubernetes"
 echo "Deploying Prometheus CRDs"
 helm upgrade --install prometheus-crds prometheus-community/prometheus-operator-crds
 
+echo "Deploying Mesh"
 FILES=("values-opentelemetry-demo.yaml" "values-prometheus-remote-otel.yaml")
-cp "${FILES[@]}" /tmp
-if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
-  for FILE in "${FILES[@]}"; do
-    sed "s/-${CENTRAL}//" "${FILE}" > "/tmp/${FILE}"
-  done
-else
-  if [[ "${ISTIO_ENABLED}" == "yes" ]]; then
-    echo "Deploying Istio"
-    . deploy-istio.sh
-  else
-    echo "Deploying Linkerd"
-    . deploy-linkerd.sh
-  fi
-fi
-
-echo "Connect to Central"
-. deploy-link.sh
+. deploy-mesh.sh
 
 echo "Deploying Prometheus (for local Kubernetes Metrics)"
 helm upgrade --install monitor prometheus-community/kube-prometheus-stack \
-  -n observability -f values-prometheus-common.yaml -f /tmp/values-prometheus-remote-otel.yaml \
-  --set prometheusOperator.clusterDomain=$DOMAIN --wait
+  -n observability -f values-prometheus-common.yaml -f /tmp/values-prometheus-remote-otel.yaml --wait
 
 echo "Deploying OpenTelemetry Demo application"
 helm upgrade --install demo open-telemetry/opentelemetry-demo \

--- a/deploy-remote.sh
+++ b/deploy-remote.sh
@@ -16,7 +16,8 @@ WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-2} # Unique on each cluster
 POD_CIDR=${POD_CIDR-10.21.0.0/16} # Unique on each cluster
 SVC_CIDR=${SVC_CIDR-10.22.0.0/16} # Unique on each cluster
-CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no} # no for Linkerd or Istio, yes for Cilium CM
+ISTIO_ENABLED=${ISTIO_ENABLED-no} # no for Linkerd, yes for Istio
 APP_NS="tns"  # Used by deploy-link.sh
 
 echo "Deploying Kubernetes"
@@ -32,8 +33,13 @@ if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
     sed "s/-${CENTRAL}//" "${FILE}" > "/tmp/${FILE}"
   done
 else
-  echo "Deploying Linkerd"
-  . deploy-linkerd.sh
+  if [[ "${ISTIO_ENABLED}" == "yes" ]]; then
+    echo "Deploying Istio"
+    . deploy-istio.sh
+  else
+    echo "Deploying Linkerd"
+    . deploy-linkerd.sh
+  fi
 fi
 
 echo "Connect to Central"

--- a/values-ingress.yaml
+++ b/values-ingress.yaml
@@ -10,10 +10,14 @@ controller:
       namespace: ingress-nginx
       additionalLabels:
         release: monitor
+  podLabels:
+    sidecar.istio.io/inject: 'true'
   podAnnotations:
     linkerd.io/inject: enabled
     config.linkerd.io/skip-inbound-ports: "80,443"
   admissionWebhooks:
+    labels:
+      sidecar.istio.io/inject: 'false'
     annotations:
       linkerd.io/inject: disabled
   updateStrategy:

--- a/values-minio.yaml
+++ b/values-minio.yaml
@@ -52,6 +52,7 @@ buckets:
 postJob:
   podAnnotations:
     linkerd.io/inject: 'disabled'
+    sidecar.istio.io/inject: 'false'
 
 metrics:
   serviceMonitor:

--- a/values-prometheus-common.yaml
+++ b/values-prometheus-common.yaml
@@ -34,6 +34,8 @@ grafana:
   enabled: false
 
 prometheus-node-exporter:
+  podLabels:
+    sidecar.istio.io/inject: 'true'
   podAnnotations:
     linkerd.io/inject: 'enabled'
 
@@ -45,6 +47,7 @@ prometheusOperator:
     patch:
       podAnnotations:
         linkerd.io/inject: 'disabled'
+        sidecar.istio.io/inject: 'false'
   prometheusConfigReloader:
     resources:
       requests:

--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -37,6 +37,10 @@ gateway:
 minio:
   enabled: false
 
+memberlist:
+  rejoin_interval: 60s
+  dead_node_reclaim_time: 60s
+
 distributor:
   replicas: 2
   appProtocol:

--- a/values-tempo.yaml
+++ b/values-tempo.yaml
@@ -11,6 +11,8 @@ tempo:
   structuredConfig:
     usage_report:
       reporting_enabled: false
+  memberlist:
+    appProtocol: tcp
 
 multitenancyEnabled: true
 
@@ -37,9 +39,17 @@ minio:
 
 distributor:
   replicas: 2
+  appProtocol:
+    grpc: tcp
+
+ingester:
+  appProtocol:
+    grpc: tcp
 
 queryFrontend:
   replicas: 2
+  appProtocol:
+    grpc: tcp
   config:
     search:
       # The following are defaults but show how to control where to query
@@ -48,10 +58,14 @@ queryFrontend:
 
 querier:
   replicas: 3
+  appProtocol:
+    grpc: tcp
 
 metricsGenerator:
   enabled: true
   replicas: 2
+  appProtocol:
+    grpc: tcp
   config:
     processor:
       service_graphs:


### PR DESCRIPTION
This is the first step in adding Istio support for the LGTM stack.

The Helm charts for Grafana Labs applications have been updated to set `appProtocol` for the Kubernetes services. The Helm charts already define headless services for each microservice, which is crucial for having endpoints on the Istio Proxy per Pod IP, as Grafana applications require direct pod-to-pod communication by Pod IP.

The only application that doesn't explicitly set `appProtocol` or make it configurable is Mimir, except for the Memberlist service, but it seems to be working.

I found that dealing with custom TrustDomain on Istio is challenging and will introduce complexity that's not required in this PoC. Here is some documentation about how to do it:

https://istio.io/latest/docs/tasks/security/authorization/authz-td-migration/
https://tetrate.io/blog/multicluster-istio/ 

Therefore, I removed having a custom cluster domain on each Kubernetes cluster and let them use the default `cluster.local`. Handling custom domains is more accessible on Linkerd, and Cilium doesn't care, so it doesn't matter not having them in place.

Integration with Prometheus and Grafana Allow/Tempo is still pending.