### PR TITLE
Removing flags not needed for Istio 1.25.0

### DIFF
--- a/deploy-istio.sh
+++ b/deploy-istio.sh
@@ -39,6 +39,7 @@ kubectl create secret generic cacerts -n istio-system \
 
 # https://istio.io/latest/docs/setup/install/multicluster/multi-primary_multi-network/
 # https://istio.io/latest/docs/reference/config/istio.operator.v1alpha1/
+# Removing resource requests and limits for demo purposes
 cat <<EOF | istioctl install -y -f -
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -68,9 +69,6 @@ spec:
   meshConfig:
     defaultConfig:
       holdApplicationUntilProxyStarts: true
-      proxyMetadata:
-        ISTIO_META_DNS_CAPTURE: "true"
-        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
     enableTracing: ${TRACES_ENABLED}
     extensionProviders:
     - name: otel-tracing

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -36,4 +36,3 @@ helm upgrade --install monitor prometheus-community/kube-prometheus-stack \
 echo "Deploying OpenTelemetry Demo application"
 helm upgrade --install demo open-telemetry/opentelemetry-demo \
   -n ${APP_NS} -f /tmp/values-opentelemetry-demo.yaml
-kubectl rollout status -n otel deployment/demo-otelcol


### PR DESCRIPTION
I tested with Istio 1.25.0, and everything still works as expected.

Bonus: Fix an issue with the OTEL collector environment.