### PR TITLE
Allow using MetalLB plus the default Kind CNI instead of Cilium.

### DIFF
--- a/deploy-central.sh
+++ b/deploy-central.sh
@@ -9,7 +9,7 @@ done
 
 CERT_ISSUER_ID=${CERT_ISSUER_ID-issuer-central}
 CONTEXT=${CONTEXT-lgtm-central}
-SUBNET=${SUBNET-248} # For Cilium L2/LB (must be unique across all clusters)
+SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for LoadBalancer IPs
 WORKERS=${WORKERS-3}
 CLUSTER_ID=${CLUSTER_ID-1} # Unique on each cluster
 POD_CIDR=${POD_CIDR-10.11.0.0/16} # Unique on each cluster
@@ -29,6 +29,7 @@ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo add vector https://helm.vector.dev
 helm repo add minio https://charts.min.io/
+helm repo add metallb https://metallb.github.io/metallb
 helm repo update &> /dev/null
 
 echo "Deploying Kubernetes"

--- a/deploy-kind.sh
+++ b/deploy-kind.sh
@@ -9,12 +9,13 @@ done
 
 CONTEXT=${CONTEXT-kind} # Kubeconfig profile
 WORKERS=${WORKERS-2} # Number of worker nodes in the clusters
-SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for Cilium L2/LB
+SUBNET=${SUBNET-248} # Last octet from the /29 CIDR subnet to use for LoadBalancer IPs
 CLUSTER_ID=${CLUSTER_ID-1}
-POD_CIDR=${POD_CIDR-10.244.0.0/16} # Must be under 10.0.0.0/8 for Cilium ipv4NativeRoutingCIDR
+POD_CIDR=${POD_CIDR-10.244.0.0/16} # Pod subnet for the cluster (when using Cilium, it must be under 10.0.0.0/8 for ipv4NativeRoutingCIDR)
 SVC_CIDR=${SVC_CIDR-10.96.0.0/16} # Must differ from Kind's Docker Network
-CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 HOST_IP=${HOST_IP-127.0.0.1} # The IP address of your machine to expose API Server (don't change when using Docker-based solutions)
+CILIUM_ENABLED=${CILIUM_ENABLED-yes} # Set to 'yes' to use Cilium as CNI or 'no' to use default CNI plus MetalLB
+CILIUM_CLUSTER_MESH_ENABLED=${CILIUM_CLUSTER_MESH_ENABLED-no}
 
 HUBBLE_ENABLED="false"
 ENCRYPTION_ENABLED="false"
@@ -46,6 +47,12 @@ EOF
 )$'\n'
 done
 
+NETWORKING_CONFIG="ipFamily: ipv4"
+if [[ "${CILIUM_ENABLED}" == "yes" ]]; then
+  # Cilium configuration: disable default CNI and kube-proxy
+  NETWORKING_CONFIG+=$'\n  disableDefaultCNI: true\n  kubeProxyMode: none'
+fi
+
 # Deploy Kind Cluster
 cat <<EOF | kind create cluster --config -
 kind: Cluster
@@ -55,44 +62,11 @@ nodes:
 - role: control-plane
 ${WORKER_YAML}
 networking:
-  ipFamily: ipv4
-  disableDefaultCNI: true
-  kubeProxyMode: none
+  ${NETWORKING_CONFIG}
   apiServerAddress: ${HOST_IP}
   podSubnet: ${POD_CIDR}
   serviceSubnet: ${SVC_CIDR}
 EOF
-
-if [ -e cilium-ca.crt ] && [ -e cilium-ca.key ]; then
-  kubectl create secret generic cilium-ca -n kube-system --from-file=ca.crt=cilium-ca.crt --from-file=ca.key=cilium-ca.key
-  kubectl label secret -n kube-system cilium-ca app.kubernetes.io/managed-by=Helm
-  kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-name=cilium
-  kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-namespace=kube-system
-fi
-
-cilium install --wait \
-  --set ipv4NativeRoutingCIDR=10.0.0.0/8 \
-  --set routingMode=native \
-  --set autoDirectNodeRoutes=true \
-  --set bpf.masquerade=false \
-  --set cluster.id=${CLUSTER_ID} \
-  --set cluster.name=${CONTEXT} \
-  --set ipam.mode=kubernetes \
-  --set cni.exclusive=false \
-  --set envoy.enabled=false \
-  --set devices=eth+ \
-  --set l2announcements.enabled=true \
-  --set externalIPs.enabled=true \
-  --set socketLB.enabled=true \
-  --set socketLB.hostNamespaceOnly=true \
-  --set k8sClientRateLimit.qps=50 \
-  --set k8sClientRateLimit.burst=100 \
-  --set encryption.enabled=${ENCRYPTION_ENABLED} \
-  --set encryption.type=wireguard \
-  --set hubble.relay.enabled=${HUBBLE_ENABLED} \
-  --set hubble.ui.enabled=${HUBBLE_ENABLED}
-
-cilium status --wait --ignore-warnings
 
 NETWORK=$(docker network inspect kind \
   | jq -r '.[0].IPAM.Config[] | select(.Gateway != null) | .Subnet' | grep -v ':')
@@ -108,7 +82,41 @@ if [[ "$CIDR" == "" ]]; then
   exit 1
 fi
 
-cat <<EOF | kubectl apply -f -
+if [[ "${CILIUM_ENABLED}" == "yes" ]]; then
+  echo "Installing Cilium CNI..."
+
+  if [ -e cilium-ca.crt ] && [ -e cilium-ca.key ]; then
+    kubectl create secret generic cilium-ca -n kube-system --from-file=ca.crt=cilium-ca.crt --from-file=ca.key=cilium-ca.key
+    kubectl label secret -n kube-system cilium-ca app.kubernetes.io/managed-by=Helm
+    kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-name=cilium
+    kubectl annotate secret -n kube-system cilium-ca meta.helm.sh/release-namespace=kube-system
+  fi
+
+  cilium install --wait \
+    --set ipv4NativeRoutingCIDR=10.0.0.0/8 \
+    --set routingMode=native \
+    --set autoDirectNodeRoutes=true \
+    --set bpf.masquerade=false \
+    --set cluster.id=${CLUSTER_ID} \
+    --set cluster.name=${CONTEXT} \
+    --set ipam.mode=kubernetes \
+    --set cni.exclusive=false \
+    --set envoy.enabled=false \
+    --set devices=eth+ \
+    --set l2announcements.enabled=true \
+    --set externalIPs.enabled=true \
+    --set socketLB.enabled=true \
+    --set socketLB.hostNamespaceOnly=true \
+    --set k8sClientRateLimit.qps=50 \
+    --set k8sClientRateLimit.burst=100 \
+    --set encryption.enabled=${ENCRYPTION_ENABLED} \
+    --set encryption.type=wireguard \
+    --set hubble.relay.enabled=${HUBBLE_ENABLED} \
+    --set hubble.ui.enabled=${HUBBLE_ENABLED}
+
+  cilium status --wait --ignore-warnings
+
+  cat <<EOF | kubectl apply -f -
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
@@ -133,9 +141,38 @@ spec:
   loadBalancerIPs: true
 EOF
 
-if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
-  cilium clustermesh enable --service-type LoadBalancer --enable-kvstoremesh=false
-  cilium clustermesh status --wait
+  if [[ "${CILIUM_CLUSTER_MESH_ENABLED}" == "yes" ]]; then
+    cilium clustermesh enable --service-type LoadBalancer --enable-kvstoremesh=false
+    cilium clustermesh status --wait
+  fi
+else
+  echo "Installing MetalLB LoadBalancer..."
+
+  helm upgrade --install metallb metallb/metallb \
+    --namespace metallb-system \
+    --create-namespace \
+    --wait
+
+  cat <<EOF | kubectl apply -f -
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: ${CONTEXT}-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - ${CIDR}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: ${CONTEXT}-l2advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - ${CONTEXT}-pool
+EOF
 fi
 
 helm upgrade --install metrics-server metrics-server/metrics-server \

--- a/deploy-mesh.sh
+++ b/deploy-mesh.sh
@@ -86,7 +86,7 @@ else
     istioctl create-remote-secret \
       --context=${CENTRAL_CTX} \
       --server https://${API_SERVER}:6443 \
-      --name=central | \
+      --name=${CENTRAL} | \
       kubectl --context ${REMOTE_CTX} apply -f -
   else
     linkerd mc link --context ${CENTRAL_CTX} --cluster-name ${CENTRAL} \

--- a/deploy-remote-otel.sh
+++ b/deploy-remote-otel.sh
@@ -10,7 +10,7 @@ done
 CENTRAL=${CENTRAL-lgtm-central}
 CERT_ISSUER_ID=${CERT_ISSUER_ID-issuer-otel}
 CONTEXT=${CONTEXT-lgtm-remote-otel}
-SUBNET=${SUBNET-232} # For Cilium L2/LB (must be unique across all clusters)
+SUBNET=${SUBNET-232} # Last octet from the /29 CIDR subnet to use for LoadBalancer IPs
 WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-3} # Unique on each cluster
 POD_CIDR=${POD_CIDR-10.31.0.0/16} # Unique on each cluster

--- a/deploy-remote.sh
+++ b/deploy-remote.sh
@@ -10,7 +10,7 @@ done
 CENTRAL=${CENTRAL-lgtm-central}
 CERT_ISSUER_ID=${CERT_ISSUER_ID-issuer-remote}
 CONTEXT=${CONTEXT-lgtm-remote}
-SUBNET=${SUBNET-240} # For Cilium L2/LB (must be unique across all clusters)
+SUBNET=${SUBNET-240} # Last octet from the /29 CIDR subnet to use for LoadBalancer IPs
 WORKERS=${WORKERS-1}
 CLUSTER_ID=${CLUSTER_ID-2} # Unique on each cluster
 POD_CIDR=${POD_CIDR-10.21.0.0/16} # Unique on each cluster


### PR DESCRIPTION
As I was able to validate in my other repository:
https://github.com/agalue/istio-playground/

Conflicts arise between Istio Ambient and Cilium when running Istio Multi-Cluster with DNS resolution, prompting the need for an alternative solution based on Kind's default CNI and MetalLB.

Unfortunately, despite those changes, I'm still experiencing DNS issues, even though the example from the above repository works, which is essentially what you can find in the Istio official documentation.